### PR TITLE
Optional plotting dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Then clone the repository and install it with pip:
 ```commandline
 git clone https://github.com/SBC-Utrecht/pytom-template-matching-gpu.git
 cd pytom-template-matching-gpu
+pip install .[plotting]
+```
+
+The installation above also adds the optional dependencies [matplotlib, seaborn] which are required to run pytom_estimate_roc.py. They are not essential to the core template matching fucntionality, so for some systems (such as certain cluster environments) it might be desirable to skip them. In that case remove '[plotting]' from the pip install command:
+
+```commandline
 pip install .
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd pytom-template-matching-gpu
 pip install .[plotting]
 ```
 
-The installation above also adds the optional dependencies [matplotlib, seaborn] which are required to run pytom_estimate_roc.py. They are not essential to the core template matching fucntionality, so for some systems (such as certain cluster environments) it might be desirable to skip them. In that case remove '[plotting]' from the pip install command:
+The installation above also adds the optional dependencies `[matplotlib, seaborn]` which are required to run `pytom_estimate_roc.py`. They are not essential to the core template matching fucntionality, so for some systems (such as certain cluster environments) it might be desirable to skip them. In that case remove `[plotting]` from the pip install command:
 
 ```commandline
 pip install .

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setuptools.setup(
         'starfile',
         'importlib_resources'
     ],
+    extras_require={
+        'plotting': ['matplotlib', 'seaborn']
+    },
     package_data={
         'pytom_tm.angle_lists': ['*.txt'],
     },


### PR DESCRIPTION
The estimate_roc script requires matplotlib and seaborn, so adding them as optional dependencies is the best way to do it.