### PR TITLE
patch for handling input which has unequal spacing

### DIFF
--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -69,9 +69,7 @@ class ParseTiltAngles(argparse.Action):
 
 
 class UnequalSpacingError(Exception):
-    def __init__(self, message):
-        # Call the base class constructor with the parameters it needs
-        super().__init__(message)
+    pass
 
 
 def write_angle_list(data: npt.NDArray[float], file_name: pathlib.Path, order: tuple[int, int, int] = (0, 2, 1)):

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -68,6 +68,12 @@ class ParseTiltAngles(argparse.Action):
             parser.error("{0} can only take one or two arguments".format(option_string))
 
 
+class UnequalSpacingError(Exception):
+    def __init__(self, message):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+
+
 def write_angle_list(data: npt.NDArray[float], file_name: pathlib.Path, order: tuple[int, int, int] = (0, 2, 1)):
     with open(file_name, 'w') as fstream:
         for i in range(data.shape[1]):
@@ -79,7 +85,7 @@ def read_mrc_meta_data(file_name: pathlib.Path) -> dict:
     with mrcfile.mmap(file_name) as mrc:
         meta_data['shape'] = tuple(map(int, attrgetter('nx', 'ny', 'nz')(mrc.header)))
         if not all([mrc.voxel_size.x == s for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
-            raise ValueError('Input volume voxel spacing is not identical in each dimension!')
+            raise UnequalSpacingError('Input volume voxel spacing is not identical in each dimension!')
         else:
             meta_data['voxel_size'] = float(mrc.voxel_size.x)
     return meta_data

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -79,7 +79,7 @@ def read_mrc_meta_data(file_name: pathlib.Path) -> dict:
     with mrcfile.mmap(file_name) as mrc:
         meta_data['shape'] = tuple(map(int, attrgetter('nx', 'ny', 'nz')(mrc.header)))
         if not all([mrc.voxel_size.x == s for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
-            raise ValueError('Input tomogram voxel spacing is not identical in each dimension!')
+            raise ValueError('Input volume voxel spacing is not identical in each dimension!')
         else:
             meta_data['voxel_size'] = float(mrc.voxel_size.x)
     return meta_data

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -2,12 +2,13 @@ import unittest
 import pathlib
 import numpy as np
 import voltools as vt
+import mrcfile
 from importlib_resources import files
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import load_angle_list
 from pytom_tm.parallel import run_job_parallel
 from pytom_tm.tmjob import TMJob, TMJobError
-from pytom_tm.io import read_mrc, write_mrc
+from pytom_tm.io import read_mrc, write_mrc, UnequalSpacingError
 
 
 TOMO_SHAPE = (100, 107, 59)
@@ -18,6 +19,7 @@ ANGULAR_SEARCH = 'angles_38.53_256.txt'
 TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath('test_data')
 TEST_TOMOGRAM = TEST_DATA_DIR.joinpath('tomogram.mrc')
 TEST_TEMPLATE = TEST_DATA_DIR.joinpath('template.mrc')
+TEST_TEMPLATE_UNEQUAL_SPACING = TEST_DATA_DIR.joinpath('template_unequal_spacing.mrc')
 TEST_TEMPLATE_WRONG_VOXEL_SIZE = TEST_DATA_DIR.joinpath('template_voxel_error_test.mrc')
 TEST_MASK = TEST_DATA_DIR.joinpath('mask.mrc')
 TEST_SCORES = TEST_DATA_DIR.joinpath('tomogram_scores.mrc')
@@ -52,6 +54,7 @@ class TestTMJob(unittest.TestCase):
         write_mrc(TEST_MASK, mask, 1.)
         write_mrc(TEST_TEMPLATE, template, 1.)
         write_mrc(TEST_TEMPLATE_WRONG_VOXEL_SIZE, template, 1.5)
+        mrcfile.write(TEST_TEMPLATE_UNEQUAL_SPACING, template, voxel_size=(1.5, 1., 2.), overwrite=True)
         write_mrc(TEST_TOMOGRAM, volume, 1.)
 
         # do a run without splitting to compare against
@@ -81,6 +84,7 @@ class TestTMJob(unittest.TestCase):
     def tearDownClass(cls) -> None:
         TEST_MASK.unlink()
         TEST_TEMPLATE.unlink()
+        TEST_TEMPLATE_UNEQUAL_SPACING.unlink()
         TEST_TEMPLATE_WRONG_VOXEL_SIZE.unlink()
         TEST_TOMOGRAM.unlink()
         TEST_SCORES.unlink()
@@ -95,6 +99,10 @@ class TestTMJob(unittest.TestCase):
         with self.assertRaises(ValueError, msg='Different voxel size in tomogram and template and no voxel size '
                                                'provided should raise a ValueError'):
             TMJob('0', 10, TEST_TOMOGRAM, TEST_TEMPLATE_WRONG_VOXEL_SIZE, TEST_MASK, TEST_DATA_DIR)
+
+        with self.assertRaises(UnequalSpacingError,
+                               msg='Unequal spacing should raise specific Error'):
+            TMJob('0', 10, TEST_TOMOGRAM, TEST_TEMPLATE_UNEQUAL_SPACING, TEST_MASK, TEST_DATA_DIR)
 
         # test searches raise correct errors
         for param in ['search_x', 'search_y', 'search_z']:


### PR DESCRIPTION
Previous PR created some merge conflicts because main and this both changes test_tmjob.py. So this should do it.

- Function should mention volume instead of tomogram as it not only applies for tomograms.
- added error class for unequal spacing
- user is notified whether template or tomogram has unequal spacing
-  added unittest for assertion

See issue #26