### PR TITLE
more lenient for slightly different spacings accross dimensions

### DIFF
--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -85,6 +85,10 @@ def read_mrc_meta_data(file_name: pathlib.Path, permissive: bool = True) -> dict
         if not all([round(mrc.voxel_size.x, 2) == round(s, 2) for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
             raise UnequalSpacingError('Input volume voxel spacing is not identical in each dimension!')
         else:
+            if not all([mrc.voxel_size.x == s for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
+                logging.warning(f'Voxel size annotation in MRC is slightly different between dimensions, '
+                                f'namely {mrc.voxel_size}. It might be a tiny numerical inaccuracy, but '
+                                f'please ensure this is not problematic.')
             meta_data['voxel_size'] = float(mrc.voxel_size.x)
     return meta_data
 

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -82,7 +82,7 @@ def read_mrc_meta_data(file_name: pathlib.Path, permissive: bool = True) -> dict
     meta_data = {}
     with mrcfile.mmap(file_name, permissive=permissive) as mrc:
         meta_data['shape'] = tuple(map(int, attrgetter('nx', 'ny', 'nz')(mrc.header)))
-        if not all([mrc.voxel_size.x == s for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
+        if not all([round(mrc.voxel_size.x, 2) == round(s, 2) for s in attrgetter('x', 'y', 'z')(mrc.voxel_size)]):
             raise UnequalSpacingError('Input volume voxel spacing is not identical in each dimension!')
         else:
             meta_data['voxel_size'] = float(mrc.voxel_size.x)


### PR DESCRIPTION
Closes #26.

One could argue that it is not up to use to be lenient with this, however I also noticed some small numerical differences myself at some point. A voxel size within 2 decimal angstrom should be sufficiently accurate for template matching and only if there are larger differences it is critical to give an error. I added a user warning though to make the user aware.