### PR TITLE
Extraction mask feature

### DIFF
--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -14,6 +14,11 @@ def main():
     parser.add_argument('-j', '--job-file', type=pathlib.Path, required=True, action=CheckFileExists,
                         help='JSON file that contain all data on the template matching job, written out by '
                              'pytom_match_template.py in the destination path.')
+    parser.add_argument('--tomogram-mask', type=pathlib.Path, required=False, action=CheckFileExists,
+                        help='Here you can provide a mask for the extraction with dimensions equal to the '
+                             'tomogram. All values in the mask that are smaller or equal to 0 will be removed, '
+                             'all values larger than 0 are considered regions of interest. It can be used to extract '
+                             'annotations only within a specific cellular region.')
     parser.add_argument('-n', '--number-of-particles', type=int, required=True, action=LargerThanZero,
                         help='Maximum number of particles to extract from tomogram.')
     parser.add_argument('--number-of-false-positives', type=int, required=False, action=LargerThanZero,
@@ -41,7 +46,8 @@ def main():
         args.radius_px,
         args.number_of_particles,
         cut_off=args.cut_off,
-        n_false_positives=args.number_of_false_positives
+        n_false_positives=args.number_of_false_positives,
+        tomogram_mask_path=args.tomogram_mask
     )
 
     # write out as a RELION type starfile

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.typing as npt
 import logging
 import scipy.ndimage as ndimage
+import pathlib
 from typing import Optional
 from pytom_tm.tmjob import TMJob
 from pytom_tm.mask import spherical_mask
@@ -10,7 +11,7 @@ from pytom_tm.angles import load_angle_list, convert_euler
 from pytom_tm.io import read_mrc
 from scipy.special import erfcinv
 from tqdm import tqdm
-from functools import reduce
+# from functools import reduce
 
 
 def detect_blobs(
@@ -30,7 +31,8 @@ def extract_particles(
         particle_radius_px: int,
         n_particles: int,
         cut_off: Optional[float] = None,
-        n_false_positives: int = 1
+        n_false_positives: int = 1,
+        tomogram_mask_path: Optional[pathlib.Path] = None
 ) -> tuple[pd.DataFrame, list[float, ...]]:
 
     score_volume = read_mrc(job.output_dir.joinpath(f'{job.tomo_id}_scores.mrc'))
@@ -45,13 +47,22 @@ def extract_particles(
     score_volume[:, -particle_radius_px:, :] = -1
     score_volume[:, :, -particle_radius_px:] = -1
 
+    # apply tomogram mask if provided
+    if tomogram_mask_path is not None:
+        tomogram_mask = read_mrc(tomogram_mask_path)[
+            job.search_origin[0]: job.search_origin[0] + job.search_size[0],
+            job.search_origin[1]: job.search_origin[1] + job.search_size[1],
+            job.search_origin[2]: job.search_origin[2] + job.search_size[2]
+        ]
+        score_volume[tomogram_mask <= 0] = -1
+
     if cut_off is None:
-        # formular rickgauer (2017) should be: 10**-13 = erfc( theta / ( sigma * sqrt(2) ) ) / 2
-        # search_space = job.job_stats['search_space']
+        # formula rickgauer (2017) should be: 10**-13 = erfc( theta / ( sigma * sqrt(2) ) ) / 2
         sigma = job.job_stats['std']
         search_space = (
-                reduce(lambda x, y: x * y, [s - 2 * particle_radius_px for s in score_volume.shape]) *
-                job.n_rotations
+            # wherever the score volume has not been explicitly set to -1 is the size of the search region
+            ((score_volume != -1) * 1).sum() *
+            job.n_rotations
         )
         cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * sigma
         logging.info(f'cut off for particle extraction: {cut_off}')

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -73,7 +73,7 @@ def extract_particles(
 
     # data for star file
     pixel_size = job.voxel_size
-    tomogram_id = job.tomo_id + '.mrc'
+    tomogram_id = job.tomo_id
 
     data = []
     scores = []

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -11,7 +11,6 @@ from pytom_tm.angles import load_angle_list, convert_euler
 from pytom_tm.io import read_mrc
 from scipy.special import erfcinv
 from tqdm import tqdm
-# from functools import reduce
 
 
 def detect_blobs(

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -61,7 +61,7 @@ def extract_particles(
         sigma = job.job_stats['std']
         search_space = (
             # wherever the score volume has not been explicitly set to -1 is the size of the search region
-            ((score_volume != -1) * 1).sum() *
+            (score_volume > -1).sum() *
             job.n_rotations
         )
         cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * sigma


### PR DESCRIPTION
This closes #36 and closes #11.

The candidate extraction accepts a mask for a specific region of interest in the tomogram. Aimed at allowing users to extract particles within some cellular context.

Also added tests to ensure masked areas are extracted (or not).

