### PR TITLE
Update warning for "no filter resolution"

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -37,8 +37,8 @@ def generate_template_from_map(
         )
 
     if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
-        logging.warning(f'Resolution is either not specified (in which case you can ignore this warning) '
-                        f'or incorrectly specified, changing to {2 * output_spacing}A')
+        logging.warning(f'Filter resolution is either not specified (in which case you can ignore this warning) '
+                        f'or too low, changing to {2 * output_spacing}A (2 * output voxel size)')
         filter_to_resolution = 2 * output_spacing
 
     # extend volume to the desired output size before applying convolutions!


### PR DESCRIPTION
Closes #46 by updating the warning to be more verbose about which resolution is not given