### PR TITLE
reduce angular search space by applying symmetry

### DIFF
--- a/src/bin/pytom_match_template.py
+++ b/src/bin/pytom_match_template.py
@@ -38,9 +38,9 @@ def main():
     parser.add_argument('--angular-search', type=str, required=True,
                         help='Options are: [7.00, 35.76, 19.95, 90.00, 18.00, '
                              '12.85, 38.53, 11.00, 17.86, 25.25, 50.00, 3.00]')
-    parser.add_argument('--symmetry', type=int, required=False, action=LargerThanZero, default=1,
-                        help='Reduce the angular search for symmetrical particles. The length of the rotation '
-                             'search will be shortened through division by this value.')
+    parser.add_argument('--rotational-symmetry', type=int, required=False, action=LargerThanZero, default=1,
+                        help='Integer value indicating the rotational symmetry of the template. The length of the '
+                             'rotation search will be shortened through division by this value.')
     parser.add_argument('-s', '--volume-split', nargs=3, type=int, required=False, default=[1, 1, 1],
                         help='Split the volume into smaller parts for the search, can be relevant if the volume does '
                              'not fit into GPU memory. Format is x y z, e.g. --volume-split 1 2 1')
@@ -122,7 +122,7 @@ def main():
         dose_accumulation=args.dose_accumulation,
         ctf_data=ctf_params,
         whiten_spectrum=args.spectral_whitening,
-        symmetry=args.symmetry,
+        rotational_symmetry=args.rotational_symmetry,
     )
 
     score_volume, angle_volume = run_job_parallel(job, tuple(args.volume_split), args.gpu_ids)

--- a/src/bin/pytom_match_template.py
+++ b/src/bin/pytom_match_template.py
@@ -38,6 +38,9 @@ def main():
     parser.add_argument('--angular-search', type=str, required=True,
                         help='Options are: [7.00, 35.76, 19.95, 90.00, 18.00, '
                              '12.85, 38.53, 11.00, 17.86, 25.25, 50.00, 3.00]')
+    parser.add_argument('--symmetry', type=int, required=False, action=LargerThanZero, default=1,
+                        help='Reduce the angular search for symmetrical particles. The length of the rotation '
+                             'search will be shortened through division by this value.')
     parser.add_argument('-s', '--volume-split', nargs=3, type=int, required=False, default=[1, 1, 1],
                         help='Split the volume into smaller parts for the search, can be relevant if the volume does '
                              'not fit into GPU memory. Format is x y z, e.g. --volume-split 1 2 1')
@@ -118,7 +121,8 @@ def main():
         high_pass=args.high_pass,
         dose_accumulation=args.dose_accumulation,
         ctf_data=ctf_params,
-        whiten_spectrum=args.spectral_whitening
+        whiten_spectrum=args.spectral_whitening,
+        symmetry=args.symmetry,
     )
 
     score_volume, angle_volume = run_job_parallel(job, tuple(args.volume_split), args.gpu_ids)

--- a/src/pytom_tm/io.py
+++ b/src/pytom_tm/io.py
@@ -34,7 +34,7 @@ class CheckFileExists(argparse.Action):
 
 
 class LargerThanZero(argparse.Action):
-    def __call__(self, parser, namespace, values: float, option_string: Optional[str] = None):
+    def __call__(self, parser, namespace, values: Union[int, float], option_string: Optional[str] = None):
         if values <= .0:
             parser.error("{0} must be larger than 0".format(option_string))
 

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -38,6 +38,7 @@ def load_json_to_tmjob(file_name: pathlib.Path) -> TMJob:
         dose_accumulation=data.get('dose_accumulation', None),
         ctf_data=data.get('ctf_data', None),
         whiten_spectrum=data.get('whiten_spectrum', False),
+        symmetry=data.get('symmetry', 1),
     )
     job.rotation_file = pathlib.Path(data['rotation_file'])
     job.whole_start = data['whole_start']
@@ -77,7 +78,8 @@ class TMJob:
             high_pass: Optional[float] = None,
             dose_accumulation: Optional[list[float, ...]] = None,
             ctf_data: Optional[list[dict, ...]] = None,
-            whiten_spectrum: bool = False
+            whiten_spectrum: bool = False,
+            symmetry: int = 1
     ):
         self.mask = mask
         self.mask_is_spherical = mask_is_spherical
@@ -141,15 +143,15 @@ class TMJob:
         self.whole_start = None
         self.sub_start, self.sub_step = None, None
 
-        # Rotations to search
+        # Rotation parameters
+        self.start_slice = 0
+        self.steps_slice = 1
+        self.symmetry = symmetry
         try:
             self.rotation_file = AVAILABLE_ROTATIONAL_SAMPLING[angle_increment][0]
             self.n_rotations = AVAILABLE_ROTATIONAL_SAMPLING[angle_increment][1]
         except KeyError:
             raise TMJobError('Provided angular search is not available in  the default lists.')
-
-        self.start_slice = 0
-        self.steps_slice = 1
 
         # missing wedge
         self.tilt_angles = tilt_angles
@@ -303,7 +305,7 @@ class TMJob:
             return result
 
         if stats is not None:
-            search_space = reduce(lambda x, y: x * y, self.search_size) * self.n_rotations
+            search_space = reduce(lambda x, y: x * y, self.search_size) * - (-self.n_rotations // self.symmetry)
             variance = sum([s['variance'] for s in stats]) / len(stats)
             std = np.sqrt(variance)
             self.job_stats = {'search_space': search_space, 'variance': variance, 'std': std}
@@ -430,8 +432,12 @@ class TMJob:
                 )
 
         # load rotation search
-        angle_ids = list(range(self.start_slice, self.n_rotations, self.steps_slice))
-        angle_list = load_angle_list(self.rotation_file)[slice(self.start_slice, self.n_rotations, self.steps_slice)]
+        angle_ids = list(range(self.start_slice, - (-self.n_rotations // self.symmetry), self.steps_slice))
+        angle_list = load_angle_list(self.rotation_file)[slice(
+            self.start_slice,
+            - (-self.n_rotations // self.symmetry),
+            self.steps_slice
+        )]
 
         tm = TemplateMatchingGPU(
             job_id=self.job_key,


### PR DESCRIPTION
Closes #29 

I added a small option to reduce angular search space for n-fold symmetrical particles.
- pytom_match_template.py has a symmetry option
- the symmetry is applied in TMJob by indexing into the angular search lists

Can this still be part of the 0.3.0 version or should I increase th version number?

