### PR TITLE
Patch for extraction cut off

### DIFF
--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -31,9 +31,9 @@ def main():
                              'around peaks preventing double extraction.')
     parser.add_argument('-c', '--cut-off', type=float, required=False,
                         help='Override automated extraction cutoff estimation and instead extract the '
-                             'number_of_particles down to this LCCmax value. Set to -1 to guarantee extracting '
-                             'number_of_particles. Values larger than 1 make no sense as the correlation cannot be '
-                             'higher than 1.')
+                             'number-of-particles down to this LCCmax value. Setting to 0 will keep extracting until '
+                             'number-of-particles, or until there are no positive values left in the score map. Values '
+                             'larger than 1 make no sense as the correlation cannot be higher than 1.')
     parser.add_argument('--log', type=str, required=False, default=20, action=ParseLogging,
                         help='Can be set to `info` or `debug`')
     args = parser.parse_args()

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -43,12 +43,12 @@ def extract_particles(
     )
 
     # mask edges of score volume
-    score_volume[0: particle_radius_px, :, :] = -1
-    score_volume[:, 0: particle_radius_px, :] = -1
-    score_volume[:, :, 0: particle_radius_px] = -1
-    score_volume[-particle_radius_px:, :, :] = -1
-    score_volume[:, -particle_radius_px:, :] = -1
-    score_volume[:, :, -particle_radius_px:] = -1
+    score_volume[0: particle_radius_px, :, :] = 0
+    score_volume[:, 0: particle_radius_px, :] = 0
+    score_volume[:, :, 0: particle_radius_px] = 0
+    score_volume[-particle_radius_px:, :, :] = 0
+    score_volume[:, -particle_radius_px:, :] = 0
+    score_volume[:, :, -particle_radius_px:] = 0
 
     # apply tomogram mask if provided
     if tomogram_mask_path is not None:
@@ -57,7 +57,7 @@ def extract_particles(
             job.search_origin[1]: job.search_origin[1] + job.search_size[1],
             job.search_origin[2]: job.search_origin[2] + job.search_size[2]
         ]
-        score_volume[tomogram_mask <= 0] = -1
+        score_volume[tomogram_mask <= 0] = 0
 
     sigma = job.job_stats['std']
     if cut_off is None:
@@ -69,6 +69,8 @@ def extract_particles(
         )
         cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * sigma
         logging.info(f'cut off for particle extraction: {cut_off}')
+    elif cut_off < 0:
+        cut_off = 0
 
     # mask for iteratively selecting peaks
     cut_box = int(particle_radius_px) * 2 + 1
@@ -87,7 +89,7 @@ def extract_particles(
 
         lcc_max = score_volume[ind]
 
-        if lcc_max < cut_off:
+        if lcc_max <= cut_off:
             break
 
         scores.append(lcc_max)


### PR DESCRIPTION
I encountered an error where `pytom_extract_candidates.py` was crashing because it was trying to extract a particle at the edge of the score volume. This should never happen as in line 46-51 the edge region is masked out.

- Regions of the score map that should not be extracted are now set to 0 instead of -1. This was leading to errors as the peak mask that was multiplied with the score map had 0 values, which lead to -1 values being reset to 0.
- This now also means the extraction cut_off cannot be smaller than 0 and the check for each particle (in extract.py line 92) is now changed to `<=` instead of `<` as this guarantees the program stops once a 0 value has been encountered as the maximum. 