### PR TITLE
Patch band pass unassigned

### DIFF
--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -431,7 +431,7 @@ class TMJob:
                 cut_off_radius=1.,
                 angles_in_degrees=True,
                 tilt_weighting=False
-            )
+            ).astype(np.float32)
             # for the template a binary or per-tilt-weighted wedge is generated depending on the options
             template_wedge *= create_wedge(
                 self.template_shape,

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -179,6 +179,8 @@ class TestTMJob(unittest.TestCase):
         score, angle = job.start_job(0, return_volumes=True)
         self.assertEqual(score.shape, job.tomo_shape, msg='TMJob with only whitening filter failed')
 
+        # TMJob with none of these weighting options is tested in all other runs in this file.
+
     def test_custom_angular_search(self):
         job = TMJob('0', 10, TEST_TOMOGRAM, TEST_TEMPLATE, TEST_MASK, TEST_DATA_DIR,
                     angle_increment=TEST_CUSTOM_ANGULAR_SEARCH, voxel_size=1.)

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -29,6 +29,7 @@ TEST_MASK = TEST_DATA_DIR.joinpath('mask.mrc')
 TEST_SCORES = TEST_DATA_DIR.joinpath('tomogram_scores.mrc')
 TEST_ANGLES = TEST_DATA_DIR.joinpath('tomogram_angles.mrc')
 TEST_CUSTOM_ANGULAR_SEARCH = TEST_DATA_DIR.joinpath('custom_angular_search.txt')
+TEST_WHITENING_FILTER = TEST_DATA_DIR.joinpath('tomogram_whitening_filter.npy')
 
 
 class TestTMJob(unittest.TestCase):
@@ -108,6 +109,9 @@ class TestTMJob(unittest.TestCase):
         TEST_SCORES.unlink()
         TEST_ANGLES.unlink()
         TEST_CUSTOM_ANGULAR_SEARCH.unlink()
+        # the whitening filter might not exist if the job with spectrum whitening failed, so the unlinking needs to
+        # allow this (with missing_ok=True) to ensure clean up of the test directory
+        TEST_WHITENING_FILTER.unlink(missing_ok=True)
         TEST_DATA_DIR.rmdir()
 
     def setUp(self):

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -91,6 +91,7 @@ DOSE_FILE = '''60.165
 65.895 
 '''
 ACCUMULATED_DOSE = [float(x.strip()) for x in DOSE_FILE.split('\n') if x != '']
+TILT_ANGLES = list(range(-51, 54, 3))
 
 
 class TestWeights(unittest.TestCase):
@@ -98,7 +99,6 @@ class TestWeights(unittest.TestCase):
         self.volume_shape_even = (10, 10, 10)
         self.volume_shape_uneven = (11, 11, 11)
         self.volume_shape_irregular = (7, 12, 6)
-        self.tilt_angles = list(range(-51, 54, 3))
         self.voxel_size = 3.34
         self.low_pass = 10
         self.high_pass = 50
@@ -180,23 +180,23 @@ class TestWeights(unittest.TestCase):
                                                'equal to 0'):
             create_wedge(
                 self.volume_shape_even,
-                self.tilt_angles,
+                TILT_ANGLES,
                 0.
             )
         with self.assertRaises(ValueError, msg='Create wedge should raise ValueError if cut_off_radius is smaller or '
                                                'equal to 0'):
             create_wedge(
                 self.volume_shape_even,
-                self.tilt_angles,
+                TILT_ANGLES,
                 1.,
                 cut_off_radius=0.
             )
 
         # create test wedges
-        structured_wedge = create_wedge(self.volume_shape_even, self.tilt_angles, 1., tilt_weighting=True)
-        symmetric_wedge = create_wedge(self.volume_shape_even, [self.tilt_angles[0], self.tilt_angles[-1]],
+        structured_wedge = create_wedge(self.volume_shape_even, TILT_ANGLES, 1., tilt_weighting=True)
+        symmetric_wedge = create_wedge(self.volume_shape_even, [TILT_ANGLES[0], TILT_ANGLES[-1]],
                                        1., tilt_weighting=False)
-        asymmetric_wedge = create_wedge(self.volume_shape_even, [self.tilt_angles[0], self.tilt_angles[-2]],
+        asymmetric_wedge = create_wedge(self.volume_shape_even, [TILT_ANGLES[0], TILT_ANGLES[-2]],
                                         1., tilt_weighting=False)
 
         self.assertEqual(structured_wedge.shape, self.reduced_even_shape_3d,
@@ -217,7 +217,7 @@ class TestWeights(unittest.TestCase):
         self.assertTrue(np.sum((symmetric_wedge != asymmetric_wedge) * 1) != 0,
                         msg='Symmetric and asymmetric wedge should be different!')
 
-        structured_wedge = create_wedge(self.volume_shape_even, self.tilt_angles, self.voxel_size, tilt_weighting=True,
+        structured_wedge = create_wedge(self.volume_shape_even, TILT_ANGLES, self.voxel_size, tilt_weighting=True,
                                         cut_off_radius=1., low_pass=self.low_pass, high_pass=self.high_pass)
         self.assertEqual(structured_wedge.shape, self.reduced_even_shape_3d,
                          msg='Wedge with band-pass does not have expected output shape')
@@ -225,13 +225,13 @@ class TestWeights(unittest.TestCase):
                          msg='Wedge with band-pass does not have expected dtype')
 
         # test shapes of wedges
-        weights = create_wedge(self.volume_shape_even, self.tilt_angles, self.voxel_size * 3,
+        weights = create_wedge(self.volume_shape_even, TILT_ANGLES, self.voxel_size * 3,
                                tilt_weighting=True, low_pass=40,
                                accumulated_dose_per_tilt=ACCUMULATED_DOSE,
                                ctf_params_per_tilt=CTF_PARAMS)
         self.assertEqual(weights.shape, self.reduced_even_shape_3d,
                          msg='3D CTF does not have the correct reduced fourier shape.')
-        weights = create_wedge(self.volume_shape_uneven, self.tilt_angles, self.voxel_size * 3,
+        weights = create_wedge(self.volume_shape_uneven, TILT_ANGLES, self.voxel_size * 3,
                                tilt_weighting=True, low_pass=40,
                                accumulated_dose_per_tilt=ACCUMULATED_DOSE,
                                ctf_params_per_tilt=CTF_PARAMS)
@@ -239,7 +239,7 @@ class TestWeights(unittest.TestCase):
                          msg='3D CTF does not have the correct reduced fourier shape.')
 
         # test parameter flexibility of tilt_weighted wedge
-        weights = create_wedge(self.volume_shape_even, self.tilt_angles, self.voxel_size * 3,
+        weights = create_wedge(self.volume_shape_even, TILT_ANGLES, self.voxel_size * 3,
                                tilt_weighting=True, low_pass=self.low_pass,
                                accumulated_dose_per_tilt=None,
                                ctf_params_per_tilt=None)

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -224,6 +224,7 @@ class TestWeights(unittest.TestCase):
         self.assertEqual(structured_wedge.dtype, np.float32,
                          msg='Wedge with band-pass does not have expected dtype')
 
+        # test shapes of wedges
         weights = create_wedge(self.volume_shape_even, self.tilt_angles, self.voxel_size * 3,
                                tilt_weighting=True, low_pass=40,
                                accumulated_dose_per_tilt=ACCUMULATED_DOSE,
@@ -236,6 +237,14 @@ class TestWeights(unittest.TestCase):
                                ctf_params_per_tilt=CTF_PARAMS)
         self.assertEqual(weights.shape, self.reduced_uneven_shape_3d,
                          msg='3D CTF does not have the correct reduced fourier shape.')
+
+        # test parameter flexibility of tilt_weighted wedge
+        weights = create_wedge(self.volume_shape_even, self.tilt_angles, self.voxel_size * 3,
+                               tilt_weighting=True, low_pass=self.low_pass,
+                               accumulated_dose_per_tilt=None,
+                               ctf_params_per_tilt=None)
+        self.assertEqual(weights.shape, self.reduced_even_shape_3d,
+                         msg='Tilt weighted wedge should also work without defocus and dose info.')
 
     def test_ctf(self):
         ctf_raw = create_ctf(


### PR DESCRIPTION
This PR will be part of the bugfixes for version 0.3.2. It solves issue #61.

I updated the tomogram (`tomogram_filter`) and template weighting generation (`template_wedge`) in `TMJob.start_job()` to solve this issue. After the addition of the spectrum whitening there are now quite some weighting options: a band-pass, a whitening-filter, and a wedge filter. They are optional but should also work together.

To make it more logical both weighting are now initialized as 1, and are multiplied with all the optional filters in when the respective flags are set. If they remain 1 (no filter flags are set) they will not modify the tomogram/template.

I updated the tests to run the job with combinations of these weighting options.

Also removed some debug volume writing as it interfered with clean up of the test data now that I made the filter creation more logical.

I am a bit uncertain about the fact that in `test_weights.py` I have some variables that store general data (CTF, dose accumulation) and load this from this file into `test_tmjob.py`, is that okay to do?
