### PR TITLE
update to minimal cutoff value in estimate_roc

### DIFF
--- a/src/bin/pytom_estimate_roc.py
+++ b/src/bin/pytom_estimate_roc.py
@@ -385,7 +385,7 @@ def main():
         template_matching_job,
         args.radius_px,
         args.number_of_particles,
-        cut_off=-1.
+        cut_off=0
     )
 
     score_volume = read_mrc(template_matching_job.output_dir.joinpath(f'{template_matching_job.tomo_id}_scores.mrc'))


### PR DESCRIPTION
The change of minimal cutoff value to 0 in version 0.3.2, was not yet updated in estimate ROC. 

(sorry for commit directly to main)