### PR TITLE
Patch unittest inconsistency

### DIFF
--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -220,18 +220,15 @@ class TestTMJob(unittest.TestCase):
         # is not well defined in the boundary area, only a small part of the template is correlated here (and we are
         # not really interested in it). Probably the inaccuracy in this area becomes more apparent when splitting
         # into subvolumes due to a smaller number of sampling points in Fourier space.
-        score_diff = np.abs(score[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                            read_mrc(TEST_SCORES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
-        angle_diff = np.abs(angle[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                            read_mrc(TEST_ANGLES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        ok_region = slice(TEMPLATE_SIZE // 2, -TEMPLATE_SIZE // 2)
+        score_diff = np.abs( 
+            score[ok_region, ok_region, ok_region] -
+            read_mrc(TEST_SCORES)[ok_region, ok_region, ok_region]
+            ).sum() 
+        angle_diff = np.abs(
+            angle[ok_region, ok_region, ok_region] -
+            read_mrc(TEST_ANGLES)[ok_region, ok_region, ok_region]
+            ).sum()
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 
@@ -273,18 +270,15 @@ class TestTMJob(unittest.TestCase):
         # is not well defined in the boundary area, only a small part of the template is correlated here (and we are
         # not really interested in it). Probably the inaccuracy in this area becomes more apparent when splitting
         # into subvolumes due to a smaller number of sampling points in Fourier space.
-        score_diff = np.abs(score[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                            read_mrc(TEST_SCORES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
-        angle_diff = np.abs(angle[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                            read_mrc(TEST_ANGLES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
-                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        ok_region = slice(TEMPLATE_SIZE // 2, -TEMPLATE_SIZE // 2)
+        score_diff = np.abs( 
+            score[ok_region, ok_region, ok_region] -
+            read_mrc(TEST_SCORES)[ok_region, ok_region, ok_region]
+            ).sum() 
+        angle_diff = np.abs(
+            angle[ok_region, ok_region, ok_region] -
+            read_mrc(TEST_ANGLES)[ok_region, ok_region, ok_region]
+            ).sum()
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -192,6 +192,10 @@ class TestTMJob(unittest.TestCase):
                                                                             'TMJob failed.')
 
     def test_tm_job_split_volume(self):
+        with self.assertRaises(RuntimeError, msg='Splitting the volume into smaller boxes than the template should '
+                                                 'raise an error.'):
+            self.job.split_volume_search((10, 3, 2))
+
         sub_jobs = self.job.split_volume_search((2, 3, 2))
         for x in sub_jobs:
             x.start_job(0)

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -192,7 +192,7 @@ class TestTMJob(unittest.TestCase):
                                                                             'TMJob failed.')
 
     def test_tm_job_split_volume(self):
-        sub_jobs = self.job.split_volume_search((1, 3, 1))
+        sub_jobs = self.job.split_volume_search((2, 3, 2))
         for x in sub_jobs:
             x.start_job(0)
             job_scores = TEST_DATA_DIR.joinpath(f'tomogram_scores_{x.job_key}.mrc')

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -216,10 +216,18 @@ class TestTMJob(unittest.TestCase):
         # is not well defined in the boundary area, only a small part of the template is correlated here (and we are
         # not really interested in it). Probably the inaccuracy in this area becomes more apparent when splitting
         # into subvolumes due to a smaller number of sampling points in Fourier space.
-        score_diff = np.abs(score[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                     read_mrc(TEST_SCORES)[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
-        angle_diff = np.abs(angle[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                     read_mrc(TEST_ANGLES)[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        score_diff = np.abs(score[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
+                            read_mrc(TEST_SCORES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        angle_diff = np.abs(angle[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
+                            read_mrc(TEST_ANGLES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 
@@ -261,10 +269,18 @@ class TestTMJob(unittest.TestCase):
         # is not well defined in the boundary area, only a small part of the template is correlated here (and we are
         # not really interested in it). Probably the inaccuracy in this area becomes more apparent when splitting
         # into subvolumes due to a smaller number of sampling points in Fourier space.
-        score_diff = np.abs(score[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                     read_mrc(TEST_SCORES)[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
-        angle_diff = np.abs(angle[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
-                     read_mrc(TEST_ANGLES)[:, TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        score_diff = np.abs(score[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
+                            read_mrc(TEST_SCORES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
+        angle_diff = np.abs(angle[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2] -
+                            read_mrc(TEST_ANGLES)[TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2,
+                            TEMPLATE_SIZE // 2: -TEMPLATE_SIZE // 2]).sum()
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 


### PR DESCRIPTION
Closes #58. 

It works! :relieved:

- Both the test_parallel_manager and test_tm_job_split_volume now only compare the score and angle volume with a distance of template_size // 2 from the edge as we expect numerical inaccuracies in those regions.
- test_tm_job_split_volume now splits along each dimensions (2,3,2) creating 12 subvolumes 
- test_parallel_manager still only splits (1,3,1) as this test should just check the parallel managing part