### PR TITLE
Bump version  to 0.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     name='pytom-template-matching-gpu',
     packages=['pytom_tm', 'pytom_tm.angle_lists'],
     package_dir={'': 'src'},
-    version='0.3.2',  # for versioning definition see https://semver.org/
+    version='0.3.3',  # for versioning definition see https://semver.org/
     description='GPU template matching from PyTOM as a lightweight pip package',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
PR to make sure the lastest version can be tagged under a new version number. Since the last version we patched the following:

- infamous unittest bug
- radial average calculation unified to single function
- minimal cutoff in estimate_roc now set correctly