### PR TITLE
Terminate other processes if one breaks

### DIFF
--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -39,7 +39,7 @@ def run_job_parallel(
     @param main_job: a TMJob object from pytom_tm that contains all data for a search
     @param volume_splits: tuple of len 3 with splits in x, y, and z
     @param gpu_ids: list of gpu indices available for the job
-    @param mute: boolean to mute spawned process terminal output, only used for unittesting
+    @param unittest_mute: boolean to mute spawned process terminal output, only used for unittesting
     @return: the volumes with the LCCmax and angle ids
     """
 

--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -93,6 +93,7 @@ def run_job_parallel(
 
                 for p in procs:  # if one of the processes is no longer alive and has a failed exit we should error
                     if not p.is_alive() and p.exitcode == 1:  # to prevent a deadlock
+                        [x.terminate() for x in procs]  # terminate all others if one breaks
                         raise RuntimeError('One of the processes stopped unexpectedly.')
 
                 time.sleep(1)

--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -16,13 +16,13 @@ except RuntimeError:
 
 
 def gpu_runner(
-        gpu_id: int, task_queue: BaseProxy, result_queue: BaseProxy, log_level: int, mute: bool
+        gpu_id: int, task_queue: BaseProxy, result_queue: BaseProxy, log_level: int, unittest_mute: bool
 ) -> None:
-    if mute:
-        mute_context = mute_stdout_stderr()  # Make sure it is imported at this time
+    if unittest_mute:
+        mute_context = mute_stdout_stderr
     else:
-        mute_context = contextlib.nullcontext()
-    with mute_context:
+        mute_context = contextlib.nullcontext
+    with mute_context():
         logging.basicConfig(level=log_level)
         while True:
             try:
@@ -33,7 +33,7 @@ def gpu_runner(
 
 
 def run_job_parallel(
-        main_job: TMJob, volume_splits: tuple[int, int, int], gpu_ids: list[int, ...], mute: bool = False,
+        main_job: TMJob, volume_splits: tuple[int, int, int], gpu_ids: list[int, ...], unittest_mute: bool = False,
 ) -> tuple[npt.NDArray[float], npt.NDArray[float]]:
     """
     @param main_job: a TMJob object from pytom_tm that contains all data for a search
@@ -90,7 +90,7 @@ def run_job_parallel(
 
             # set the processes and start them!
             procs = [mp.Process(target=gpu_runner, args=(
-                g, task_queue, result_queue, main_job.log_level, mute)) for g in gpu_ids]
+                g, task_queue, result_queue, main_job.log_level, unittest_mute)) for g in gpu_ids]
             [p.start() for p in procs]
 
             while True:

--- a/src/pytom_tm/parallel.py
+++ b/src/pytom_tm/parallel.py
@@ -93,7 +93,7 @@ def run_job_parallel(
 
                 for p in procs:  # if one of the processes is no longer alive and has a failed exit we should error
                     if not p.is_alive() and p.exitcode == 1:  # to prevent a deadlock
-                        [x.terminate() for x in procs]  # terminate all others if one breaks
+                        [x.kill() for x in procs]  # terminate all others if one breaks
                         raise RuntimeError('One of the processes stopped unexpectedly.')
 
                 time.sleep(1)

--- a/src/pytom_tm/utils.py
+++ b/src/pytom_tm/utils.py
@@ -1,0 +1,10 @@
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from os import devnull
+
+
+@contextmanager
+def mute_stdout_stderr():
+    """A context manager that redirects stdout and stderr to devnull"""
+    with open(devnull, 'w') as fnull:
+        with redirect_stderr(fnull) as err, redirect_stdout(fnull) as out:
+            yield err, out

--- a/src/pytom_tm/utils.py
+++ b/src/pytom_tm/utils.py
@@ -1,10 +1,17 @@
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
-from os import devnull
+import os
+import sys
 
 
-@contextmanager
-def mute_stdout_stderr():
-    """A context manager that redirects stdout and stderr to devnull"""
-    with open(devnull, 'w') as fnull:
-        with redirect_stderr(fnull) as err, redirect_stdout(fnull) as out:
-            yield err, out
+class mute_stdout_stderr(object):
+    def __enter__(self):
+        self.outnull = open(os.devnull, 'w')
+        self.old_stdout = sys.stdout
+        self.old_stderr = sys.stderr
+        sys.stdout = self.outnull
+        sys.stderr = self.outnull
+        return self
+
+    def __exit__(self):
+        sys.stdout = self.old_stdout
+        sys.stderr = self.old_stderr
+        self.outnull.close()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -4,8 +4,6 @@ import numpy as np
 import voltools as vt
 import mrcfile
 import multiprocessing
-import sys
-import io
 from importlib_resources import files
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import load_angle_list
@@ -263,7 +261,7 @@ class TestTMJob(unittest.TestCase):
 
     def test_parallel_breaking(self):
         try:
-            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], mute=True)
+            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], unittest_mute=True)
         except RuntimeError:
             self.assertEqual(len(multiprocessing.active_children()), 0,
                              msg='a process was still lingering after a parallel job with partially invalid resources '

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -263,7 +263,7 @@ class TestTMJob(unittest.TestCase):
 
     def test_parallel_breaking(self):
         try:
-            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1])
+            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], mute=True)
         except RuntimeError:
             self.assertEqual(len(multiprocessing.active_children()), 0,
                              msg='a process was still lingering after a parallel job with partially invalid resources '

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -3,6 +3,9 @@ import pathlib
 import numpy as np
 import voltools as vt
 import mrcfile
+import multiprocessing
+import sys
+import io
 from importlib_resources import files
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import load_angle_list
@@ -257,6 +260,14 @@ class TestTMJob(unittest.TestCase):
                         msg='split rotation search should be identical')
         self.assertTrue(np.abs(angle - read_mrc(TEST_ANGLES)).sum() == 0,
                         msg='split rotation search should be identical')
+
+    def test_parallel_breaking(self):
+        try:
+            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1])
+        except RuntimeError:
+            self.assertEqual(len(multiprocessing.active_children()), 0,
+                             msg='a process was still lingering after a parallel job with partially invalid resources '
+                                 'was started')
 
     def test_parallel_manager(self):
         score, angle = run_job_parallel(self.job, volume_splits=(1, 3, 1), gpu_ids=[0])

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -268,6 +268,8 @@ class TestTMJob(unittest.TestCase):
             self.assertEqual(len(multiprocessing.active_children()), 0,
                              msg='a process was still lingering after a parallel job with partially invalid resources '
                                  'was started')
+        else:
+            self.fail('This should have given a RuntimeError')
 
     def test_parallel_manager(self):
         score, angle = run_job_parallel(self.job, volume_splits=(1, 3, 1), gpu_ids=[0])


### PR DESCRIPTION
Noticed a multiprocessing problem (unrelated to #74). When one of the processes fails, the other will keep running. This is undesired as the results will become unusable. Now I explicitly terminate all processes when one fails before raise a runtimeerror in the main process.

(I previsouly thought that 'raise RuntimeError' would be propagated to child processes, but that is apparently not the case)