### PR TITLE
parallel manager in a separate test file

### DIFF
--- a/tests/00_test_parallel.py
+++ b/tests/00_test_parallel.py
@@ -1,3 +1,10 @@
+"""
+This file name explicitly starts with 00_ to ensure its run first during testing.
+Other tests will run jobs on the GPU which keeps the main unittest process lingering on the GPU. When starting the
+parallel manager test on a GPU in exclusive process mode, the spawned process from the parallel manager will fail due
+the occupation from the other unittests. If the parallel manager is tested first, the spawned process is fully closed
+which will allow the remaining test to use the GPU.
+"""
 import unittest
 import pathlib
 import numpy as np

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,86 @@
+import unittest
+import pathlib
+import numpy as np
+import voltools as vt
+import multiprocessing
+from importlib_resources import files
+from pytom_tm.mask import spherical_mask
+from pytom_tm.angles import load_angle_list
+from pytom_tm.parallel import run_job_parallel
+from pytom_tm.tmjob import TMJob
+from pytom_tm.io import write_mrc
+
+
+TOMO_SHAPE = (100, 107, 59)
+TEMPLATE_SIZE = 13
+LOCATION = (77, 26, 40)
+ANGLE_ID = 100
+ANGULAR_SEARCH = 'angles_38.53_256.txt'
+TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath('test_data')
+TEST_TOMOGRAM = TEST_DATA_DIR.joinpath('tomogram.mrc')
+TEST_TEMPLATE = TEST_DATA_DIR.joinpath('template.mrc')
+TEST_MASK = TEST_DATA_DIR.joinpath('mask.mrc')
+
+
+class TestTMJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Create template, mask and tomogram
+        volume = np.zeros(TOMO_SHAPE, dtype=np.float32)
+        template = np.zeros((TEMPLATE_SIZE,) * 3, dtype=np.float32)
+        template[3:8, 4:8, 3:7] = 1.
+        template[7, 8, 5:7] = 1.
+        mask = spherical_mask(TEMPLATE_SIZE, 5, 0.5)
+        rotation = load_angle_list(files('pytom_tm.angle_lists').joinpath(ANGULAR_SEARCH))[ANGLE_ID]
+
+        volume[LOCATION[0] - TEMPLATE_SIZE // 2: LOCATION[0] + TEMPLATE_SIZE // 2 + TEMPLATE_SIZE % 2,
+               LOCATION[1] - TEMPLATE_SIZE // 2: LOCATION[1] + TEMPLATE_SIZE // 2 + TEMPLATE_SIZE % 2,
+               LOCATION[2] - TEMPLATE_SIZE // 2: LOCATION[2] + TEMPLATE_SIZE // 2 + TEMPLATE_SIZE % 2] = vt.transform(
+            template,
+            rotation=rotation,
+            rotation_units='rad',
+            rotation_order='rzxz',
+            device='cpu'
+        )
+
+        # add some noise
+        rng = np.random.default_rng(0)
+        volume += rng.normal(loc=0, scale=0.1, size=volume.shape)
+
+        TEST_DATA_DIR.mkdir(exist_ok=True)
+        write_mrc(TEST_MASK, mask, 1.)
+        write_mrc(TEST_TEMPLATE, template, 1.)
+        write_mrc(TEST_TOMOGRAM, volume, 1.)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        TEST_MASK.unlink()
+        TEST_TEMPLATE.unlink()
+        TEST_TOMOGRAM.unlink()
+        TEST_DATA_DIR.rmdir()
+
+    def setUp(self):
+        self.job = TMJob('0', 10, TEST_TOMOGRAM, TEST_TEMPLATE, TEST_MASK, TEST_DATA_DIR,
+                         angle_increment='38.53', voxel_size=1.)
+
+    def test_parallel_breaking(self):
+        try:
+            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], unittest_mute=True)
+        except RuntimeError:
+            self.assertEqual(len(multiprocessing.active_children()), 0,
+                             msg='a process was still lingering after a parallel job with partially invalid resources '
+                                 'was started')
+        else:
+            self.fail('This should have given a RuntimeError')
+
+    def test_parallel_manager(self):
+        score, angle = run_job_parallel(self.job, volume_splits=(1, 3, 1), gpu_ids=[0])
+        ind = np.unravel_index(score.argmax(), score.shape)
+
+        self.assertTrue(score.max() > 0.931, msg='lcc max value lower than expected')
+        self.assertEqual(ANGLE_ID, angle[ind])
+        self.assertSequenceEqual(LOCATION, ind)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -3,11 +3,9 @@ import pathlib
 import numpy as np
 import voltools as vt
 import mrcfile
-import multiprocessing
 from importlib_resources import files
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import load_angle_list
-from pytom_tm.parallel import run_job_parallel
 from pytom_tm.tmjob import TMJob, TMJobError
 from pytom_tm.io import read_mrc, write_mrc, UnequalSpacingError
 from pytom_tm.extract import extract_particles
@@ -258,40 +256,6 @@ class TestTMJob(unittest.TestCase):
                         msg='split rotation search should be identical')
         self.assertTrue(np.abs(angle - read_mrc(TEST_ANGLES)).sum() == 0,
                         msg='split rotation search should be identical')
-
-    def test_parallel_breaking(self):
-        try:
-            _ = run_job_parallel(self.job, volume_splits=(1, 2, 1), gpu_ids=[0, -1], unittest_mute=True)
-        except RuntimeError:
-            self.assertEqual(len(multiprocessing.active_children()), 0,
-                             msg='a process was still lingering after a parallel job with partially invalid resources '
-                                 'was started')
-        else:
-            self.fail('This should have given a RuntimeError')
-
-    def test_parallel_manager(self):
-        score, angle = run_job_parallel(self.job, volume_splits=(1, 3, 1), gpu_ids=[0])
-        ind = np.unravel_index(score.argmax(), score.shape)
-
-        self.assertTrue(score.max() > 0.931, msg='lcc max value lower than expected')
-        self.assertEqual(ANGLE_ID, angle[ind])
-        self.assertSequenceEqual(LOCATION, ind)
-
-        # Small difference in the edge regions of the split dimension. This is because the cross correlation function
-        # is not well defined in the boundary area, only a small part of the template is correlated here (and we are
-        # not really interested in it). Probably the inaccuracy in this area becomes more apparent when splitting
-        # into subvolumes due to a smaller number of sampling points in Fourier space.
-        ok_region = slice(TEMPLATE_SIZE // 2, -TEMPLATE_SIZE // 2)
-        score_diff = np.abs( 
-            score[ok_region, ok_region, ok_region] -
-            read_mrc(TEST_SCORES)[ok_region, ok_region, ok_region]
-            ).sum() 
-        angle_diff = np.abs(
-            angle[ok_region, ok_region, ok_region] -
-            read_mrc(TEST_ANGLES)[ok_region, ok_region, ok_region]
-            ).sum()
-        self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
-        self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 
     def test_extraction(self):
         _ = self.job.start_job(0, return_volumes=True)


### PR DESCRIPTION
split parallel manager tests to a separate file to potentially prevent exclusive GPU process errors