### PR TITLE
Standard deviation cut-off lower threshold

### DIFF
--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -202,9 +202,8 @@ def std_under_mask_convolution(
             mean_under_mask_convolution(rfftn(volume ** 2), padded_mask, mask_weight) -
             mean_under_mask_convolution(volume_rft, padded_mask, mask_weight) ** 2
     )
-    # set extremely low values to 1 to prevent division by 0 and make sure that scores in those areas of the
-    std_v[std_v <= cp.float32(1e-18)] = 1e-18  # tomogram are not inflated
-    std_v = cp.sqrt(std_v)
+    std_v[std_v <= cp.float32(1e-18)] = 1e-18  # replace potential zeros with lower limit to prevent divide by 0
+    std_v = cp.sqrt(std_v)  # also makes sure that the sqrt of a negative value is never taken
     return std_v
 
 

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -198,12 +198,13 @@ def std_under_mask_convolution(
     std convolution of volume and mask
     """
     volume_rft = rfftn(volume) if volume_rft is None else volume_rft
-    std_v = cp.sqrt(
+    std_v = (
             mean_under_mask_convolution(rfftn(volume ** 2), padded_mask, mask_weight) -
             mean_under_mask_convolution(volume_rft, padded_mask, mask_weight) ** 2
     )
     # set extremely low values to 1 to prevent division by 0 and make sure that scores in those areas of the
-    std_v[std_v <= cp.float32(1e-18)] = 1  # tomogram are not inflated
+    std_v[std_v <= cp.float32(1e-18)] = 1e-18  # tomogram are not inflated
+    std_v = cp.sqrt(std_v)
     return std_v
 
 

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -198,12 +198,13 @@ def std_under_mask_convolution(
     std convolution of volume and mask
     """
     volume_rft = rfftn(volume) if volume_rft is None else volume_rft
-    std_v = (
+    std_v = cp.sqrt(
             mean_under_mask_convolution(rfftn(volume ** 2), padded_mask, mask_weight) -
             mean_under_mask_convolution(volume_rft, padded_mask, mask_weight) ** 2
     )
-    std_v[std_v <= cp.float32(1e-09)] = 1
-    return cp.sqrt(std_v)
+    # set extremely low values to 1 to prevent division by 0 and make sure that scores in those areas of the
+    std_v[std_v <= cp.float32(1e-18)] = 1  # tomogram are not inflated
+    return std_v
 
 
 def mean_under_mask_convolution(

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -202,7 +202,7 @@ def std_under_mask_convolution(
             mean_under_mask_convolution(rfftn(volume ** 2), padded_mask, mask_weight) -
             mean_under_mask_convolution(volume_rft, padded_mask, mask_weight) ** 2
     )
-    std_v[std_v <= cp.float32(1e-18)] = 1e-18  # replace potential zeros with lower limit to prevent divide by 0
+    std_v[std_v <= cp.float32(1e-18)] = 1  # replace potential zeros with lower limit to prevent divide by 0
     std_v = cp.sqrt(std_v)  # also makes sure that the sqrt of a negative value is never taken
     return std_v
 

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -202,8 +202,8 @@ def std_under_mask_convolution(
             mean_under_mask_convolution(rfftn(volume ** 2), padded_mask, mask_weight) -
             mean_under_mask_convolution(volume_rft, padded_mask, mask_weight) ** 2
     )
-    std_v[std_v <= cp.float32(1e-18)] = 1  # replace potential zeros with lower limit to prevent divide by 0
-    std_v = cp.sqrt(std_v)  # also makes sure that the sqrt of a negative value is never taken
+    std_v[std_v <= cp.float32(1e-18)] = 1  # prevent potential sqrt of negative value and division by zero
+    std_v = cp.sqrt(std_v)
     return std_v
 
 


### PR DESCRIPTION
Took longer than expected. 
Some observations:
- I tried taking the sqrt before the cutoff but this failed as apparently negative values can be returned from line 201. Maybe has to do with fourier transform of a square box, which has to be approximated with infinite waves in fourier space?
- Tried setting to lower limit, but this resulted in `test_template_matching.py` finding the object back in a completely wrong position.
- Leaving it at 1 but lowering the limit works, all tests pass.

As an alternative solution, I could also normalize the search volume in each process before going to the GPU template matching structure, by doing something like:
search_volume = (search_volume - search_volume.mean())/ search_volume.std()
