### PR TITLE
Make filter warning template.py conditional

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -37,8 +37,9 @@ def generate_template_from_map(
         )
 
     if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
-        logging.warning(f'Filter resolution is either not specified (in which case you can ignore this warning) '
-                        f'or too low, changing to {2 * output_spacing}A (2 * output voxel size)')
+        warning_text = (f"Filter resoltution is {'not specified' if filter_to_resolution is None else 'too low'},"
+                        f" setting to {2 * output_spacing}A (2 * output voxel size)")
+        logging.warning(warning_text)
         filter_to_resolution = 2 * output_spacing
 
     # extend volume to the desired output size before applying convolutions!


### PR DESCRIPTION
This still has to be tested, but I got a question from a novice user that thought it was bad when he did not specify the lowpass filter.