### PR TITLE
make json writing OS agnostic in tmjob.py

### DIFF
--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -216,7 +216,7 @@ class TMJob:
         d['search_y'] = [self.search_origin[1], self.search_origin[1] + self.search_size[1]]
         d['search_z'] = [self.search_origin[2], self.search_origin[2] + self.search_size[2]]
         for key, value in d.items():
-            if isinstance(value, pathlib.PosixPath):
+            if isinstance(value, pathlib.Path):
                 d[key] = str(value)
         with open(file_name, 'w') as fstream:
             json.dump(d, fstream, indent=4)


### PR DESCRIPTION
I `grep`ed through the codebase and this was the only instance of `PosixPath` that came back.
This is untestable as `pathlib.WindowsPath('.')` will error out with a `NotImplementedError` on unix systems

closes #89 