### PR TITLE
experimental tophat filtering for constraining score volume peaks at extraction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     name='pytom-template-matching-gpu',
     packages=['pytom_tm', 'pytom_tm.angle_lists'],
     package_dir={'': 'src'},
-    version='0.3.3',  # for versioning definition see https://semver.org/
+    version='0.3.4',  # for versioning definition see https://semver.org/
     description='GPU template matching from PyTOM as a lightweight pip package',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -47,10 +47,10 @@ def main():
         job,
         args.radius_px,
         args.number_of_particles,
-        n_false_positives=args.number_of_false_positives,
         cut_off=args.cut_off,
+        n_false_positives=args.number_of_false_positives,
+        tomogram_mask_path=args.tomogram_mask,
         tophat_filter=args.tophat_filter,
-        tomogram_mask_path=args.tomogram_mask
     )
 
     # write out as a RELION type starfile

--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -36,8 +36,6 @@ def main():
                              'larger than 1 make no sense as the correlation cannot be higher than 1.')
     parser.add_argument('--tophat-filter', action='store_true', default=False, required=False,
                         help='Attempt to filter only sharp correlation peaks with a tophat transform')
-    parser.add_argument('--fiducial-diameter', type=float, required=False, action=LargerThanZero,
-                        help='Specify the fiducial (gold) diameter to attempt a masking step.')
     parser.add_argument('--log', type=str, required=False, default=20, action=ParseLogging,
                         help='Can be set to `info` or `debug`')
     args = parser.parse_args()
@@ -52,7 +50,6 @@ def main():
         n_false_positives=args.number_of_false_positives,
         cut_off=args.cut_off,
         tophat_filter=args.tophat_filter,
-        gold_marker_diameter=args.fiducial_diameter,
         tomogram_mask_path=args.tomogram_mask
     )
 

--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -34,6 +34,11 @@ def main():
                              'number-of-particles down to this LCCmax value. Setting to 0 will keep extracting until '
                              'number-of-particles, or until there are no positive values left in the score map. Values '
                              'larger than 1 make no sense as the correlation cannot be higher than 1.')
+    parser.add_argument('--tophat-cut-off', type=float, required=False, action=LargerThanZero,
+                        help='Specify a cut-off for the tophat filter. ~0.1 seems to be a good value. Smaller values '
+                             'will decrease specificity, higher values will increase specificity.')
+    parser.add_argument('--fiducial-diameter', type=float, required=False, action=LargerThanZero,
+                        help='Specify the fiducial (gold) diameter to attempt a masking step.')
     parser.add_argument('--log', type=str, required=False, default=20, action=ParseLogging,
                         help='Can be set to `info` or `debug`')
     args = parser.parse_args()
@@ -45,8 +50,10 @@ def main():
         job,
         args.radius_px,
         args.number_of_particles,
-        cut_off=args.cut_off,
         n_false_positives=args.number_of_false_positives,
+        cut_off=args.cut_off,
+        tophat_filter_cut_off=args.tophat_cut_off,
+        gold_marker_diameter=args.fiducial_diameter,
         tomogram_mask_path=args.tomogram_mask
     )
 

--- a/src/bin/pytom_extract_candidates.py
+++ b/src/bin/pytom_extract_candidates.py
@@ -34,9 +34,8 @@ def main():
                              'number-of-particles down to this LCCmax value. Setting to 0 will keep extracting until '
                              'number-of-particles, or until there are no positive values left in the score map. Values '
                              'larger than 1 make no sense as the correlation cannot be higher than 1.')
-    parser.add_argument('--tophat-cut-off', type=float, required=False, action=LargerThanZero,
-                        help='Specify a cut-off for the tophat filter. ~0.1 seems to be a good value. Smaller values '
-                             'will decrease specificity, higher values will increase specificity.')
+    parser.add_argument('--tophat-filter', action='store_true', default=False, required=False,
+                        help='Attempt to filter only sharp correlation peaks with a tophat transform')
     parser.add_argument('--fiducial-diameter', type=float, required=False, action=LargerThanZero,
                         help='Specify the fiducial (gold) diameter to attempt a masking step.')
     parser.add_argument('--log', type=str, required=False, default=20, action=ParseLogging,
@@ -52,7 +51,7 @@ def main():
         args.number_of_particles,
         n_false_positives=args.number_of_false_positives,
         cut_off=args.cut_off,
-        tophat_filter_cut_off=args.tophat_cut_off,
+        tophat_filter=args.tophat_filter,
         gold_marker_diameter=args.fiducial_diameter,
         tomogram_mask_path=args.tomogram_mask
     )

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -59,6 +59,7 @@ def extract_particles(
             )
         )
         flt = layer1 * layer2
+        flt = (flt - flt.min()) / (flt.max() - flt.min())  # normalise
         tophat_cut_off = 0.1  # this is a user parameter
         flt[flt < tophat_cut_off] = 0  # threshold tophat
 

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -14,27 +14,73 @@ from scipy.special import erfcinv
 from tqdm import tqdm
 
 
-def detect_blobs(
+def predict_gold_marker_mask(
         volume: npt.NDArray[float],
         voxel_size: float,
         blob_size: float,
-        threshold: float = 1.
 ) -> npt.NDArray[int]:
+    # gold marker radius in number of voxels
     blob_radius = (blob_size / voxel_size) / 2
+
+    # Laplacian of Gaussian (LoG) filter where sigma is gaussian width corresponding to object size
     sigma = blob_radius / np.sqrt(3)
-    filtered = ndimage.gaussian_laplace((volume - volume.mean()) / volume.std(), sigma)
-    return ((filtered > threshold) * 1).astype(int)
+    log = ndimage.gaussian_laplace(volume, sigma)
+
+    # fudge factor for the number of iterations for binary opening and dilation
+    iters = int(blob_radius / (5 / 3))  # 5/3 is a fudge ratio
+
+    mask = ndimage.binary_opening(  # binary opening keeps objects that consist of plenty connected components
+        (log > log.std() * 3) * 1,  # LoG is threshold with 3x the standard deviation
+        iterations=iters,  # iterations should be more for smaller voxel spacings
+        structure=ndimage.generate_binary_structure(
+            rank=3, connectivity=1
+        )
+    )  # dilate strongly to ensure gold is fully covered
+    return ndimage.binary_dilation(
+        mask,
+        iterations=iters + 2,
+        structure=ndimage.generate_binary_structure(rank=3, connectivity=2),
+    )
 
 
 def extract_particles(
         job: TMJob,
         particle_radius_px: int,
         n_particles: int,
-        cut_off: Optional[float] = None,
         n_false_positives: int = 1,
+        cut_off: Optional[float] = None,
+        tophat_filter_cut_off: Optional[float] = None,
+        gold_marker_diameter: Optional[float] = None,
         tomogram_mask_path: Optional[pathlib.Path] = None,
-        tophat_filter: bool = False,
 ) -> tuple[pd.DataFrame, list[float, ...]]:
+    """
+    Parameters
+    ----------
+    job: pytom_tm.tmjob.TMJob
+        template matching job to annotate particles from
+    particle_radius_px: int
+        particle radius to remove peaks with after a score has been annotated
+    n_particles: int
+        maximum number of particles to extract
+    n_false_positives: int
+        tune the number of false positives to be included for automated error function cut-off estimation: default is 1;
+        lowering the value up to zero reduces sensitivity; increasing the value above 1 increases sensitivity,
+        it should roughly relate to the number of false positives (i.e. 500 expects 500 FPs)
+    cut_off: Optional[float]
+        manually override the automated score cut-off estimation, value between 0 and 1
+    tophat_filter_cut_off: Optional[float]
+        float between 0 and 1 to tune the specificity: default is 0.1; value of 1 removes everything, value of 0
+        includes everything
+    gold_marker_diameter: Optional[float]
+        average diameter of gold markers in angstrom
+    tomogram_mask_path: Optional[pathlib.Path]
+        path to a tomographic binary mask for extraction
+
+    Returns
+    -------
+    dataframe, scores: tuple[pd.DataFrame, list[float, ...]]
+        dataframe with annotations that can be written out as a STAR file and a list of the selected scores
+    """
 
     score_volume = read_mrc(job.output_dir.joinpath(f'{job.tomo_id}_scores.mrc'))
     angle_volume = read_mrc(job.output_dir.joinpath(f'{job.tomo_id}_angles.mrc'))
@@ -43,7 +89,15 @@ def extract_particles(
         sort_angles=version.parse(job.pytom_tm_version_number) > version.parse('0.3.0')
     )
 
-    if tophat_filter:  # constrain the extraction with a tophat filter
+    if gold_marker_diameter is not None:
+        mask = predict_gold_marker_mask(
+            read_mrc(job.tomograms),  # the gold mark mask is created on the tomogram
+            job.voxel_size,
+            gold_marker_diameter,
+        )  # zero all elements where gold beads are predicted
+        score_volume[mask == 1] = 0
+
+    if tophat_filter_cut_off is not None:  # constrain the extraction with a tophat filter
         layer1 = ndimage.white_tophat(
             score_volume,
             structure=ndimage.generate_binary_structure(
@@ -58,18 +112,10 @@ def extract_particles(
                 connectivity=2
             )
         )
-        flt = layer1 * layer2
-        flt = (flt - flt.min()) / (flt.max() - flt.min())  # normalise
-        tophat_cut_off = 0.1  # this is a user parameter
-        flt[flt < tophat_cut_off] = 0  # threshold tophat
-
-    # mask edges of score volume
-    score_volume[0: particle_radius_px, :, :] = 0
-    score_volume[:, 0: particle_radius_px, :] = 0
-    score_volume[:, :, 0: particle_radius_px] = 0
-    score_volume[-particle_radius_px:, :, :] = 0
-    score_volume[:, -particle_radius_px:, :] = 0
-    score_volume[:, :, -particle_radius_px:] = 0
+        tophat_filter = layer1 * layer2
+        tophat_filter = (tophat_filter - tophat_filter.min()) / (tophat_filter.max() - tophat_filter.min())
+        # zero places where the tophat filter has too small values
+        score_volume[tophat_filter < tophat_filter_cut_off] = 0  # threshold tophat
 
     # apply tomogram mask if provided
     if tomogram_mask_path is not None:
@@ -79,6 +125,14 @@ def extract_particles(
             job.search_origin[2]: job.search_origin[2] + job.search_size[2]
         ]
         score_volume[tomogram_mask <= 0] = 0
+
+    # mask edges of score volume
+    score_volume[0: particle_radius_px, :, :] = 0
+    score_volume[:, 0: particle_radius_px, :] = 0
+    score_volume[:, :, 0: particle_radius_px] = 0
+    score_volume[-particle_radius_px:, :, :] = 0
+    score_volume[:, -particle_radius_px:, :] = 0
+    score_volume[:, :, -particle_radius_px:] = 0
 
     sigma = job.job_stats['std']
     if cut_off is None:

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -98,10 +98,10 @@ def extract_particles(
         job: TMJob,
         particle_radius_px: int,
         n_particles: int,
-        n_false_positives: int = 1,
         cut_off: Optional[float] = None,
-        tophat_filter: bool = False,
+        n_false_positives: int = 1,
         tomogram_mask_path: Optional[pathlib.Path] = None,
+        tophat_filter: bool = False,
 ) -> tuple[pd.DataFrame, list[float, ...]]:
     """
     Parameters
@@ -112,15 +112,15 @@ def extract_particles(
         particle radius to remove peaks with after a score has been annotated
     n_particles: int
         maximum number of particles to extract
+    cut_off: Optional[float]
+        manually override the automated score cut-off estimation, value between 0 and 1
     n_false_positives: int
         tune the number of false positives to be included for automated error function cut-off estimation:
         should be an integer >= 1
-    cut_off: Optional[float]
-        manually override the automated score cut-off estimation, value between 0 and 1
-    tophat_filter: bool
-        attempt to only select sharp peaks with the tophat filter
     tomogram_mask_path: Optional[pathlib.Path]
         path to a tomographic binary mask for extraction
+    tophat_filter: bool
+        attempt to only select sharp peaks with the tophat filter
 
     Returns
     -------

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -45,7 +45,7 @@ def predict_tophat_mask(
     # take second derivative and discard inaccurate boundary value (hence the [2:])
     with np.errstate(divide='ignore'):
         y_log = np.log(y_raw)
-        y_log[y_log == np.inf] = 0
+        y_log[np.isinf(y_log)] = 0
     second_derivative = np.gradient(np.gradient(y_log))[2:]
     m1 = second_derivative[:-1] < 0  # where the derivative is negative
     sign = np.sign(second_derivative[1:] * second_derivative[:-1])

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -91,7 +91,7 @@ def extract_particles(
 
     if gold_marker_diameter is not None:
         mask = predict_gold_marker_mask(
-            read_mrc(job.tomograms),  # the gold mark mask is created on the tomogram
+            read_mrc(job.tomogram),  # the gold mark mask is created on the tomogram
             job.voxel_size,
             gold_marker_diameter,
         )  # zero all elements where gold beads are predicted

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -70,7 +70,9 @@ def predict_tophat_mask(
     x_raw, y_raw = (bins[2:-1] + bins[3:]) / 2, y[2:]  # discard first two bin because of over-representation of zeros
 
     # take second derivative and discard inaccurate boundary value (hence the [2:])
-    second_derivative = np.gradient(np.gradient(np.log(y_raw)))[2:]
+    with np.errstate(divide='ignore'):
+        y_log = np.where(np.log(y_raw) == np.inf, 0, np.log(y_raw))
+    second_derivative = np.gradient(np.gradient(y_log))[2:]
     m1 = second_derivative[:-1] < 0  # where the derivative is negative
     m2 = np.sign(second_derivative[1:] * second_derivative[:-1]) == -1  # switches from neg. to pos. and vice versa
     idx = (

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -104,9 +104,8 @@ def extract_particles(
     n_particles: int
         maximum number of particles to extract
     n_false_positives: int
-        tune the number of false positives to be included for automated error function cut-off estimation: default is 1;
-        lowering the value up to zero reduces sensitivity; increasing the value above 1 increases sensitivity,
-        it should roughly relate to the number of false positives (i.e. 500 expects 500 FPs)
+        tune the number of false positives to be included for automated error function cut-off estimation:
+        should be an integer >= 1
     cut_off: Optional[float]
         manually override the automated score cut-off estimation, value between 0 and 1
     tophat_filter: bool

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -71,6 +71,8 @@ def predict_tophat_mask(
     coeff = curve_fit(gauss, x_fit, y_fit, p0=guess)[0]  # first fit regular gauss to get better guesses
     coeff_log = curve_fit(log_gauss, x_fit, np.log(y_fit), p0=coeff)[0]  # now go for accurate fit to log of gauss
     search_space = coeff_log[0] / (coeff_log[2] * np.sqrt(2 * np.pi))
+    # formula Rickgauer et al. (2017, eLife): N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
+    # we need to find theta (cut off)
     cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * coeff_log[2] + coeff_log[1]
 
     if plotting_available and output_path is not None:
@@ -160,7 +162,8 @@ def extract_particles(
 
     sigma = job.job_stats['std']
     if cut_off is None:
-        # formula rickgauer (2017) should be: 10**-13 = erfc( theta / ( sigma * sqrt(2) ) ) / 2
+        # formula Rickgauer et al. (2017, eLife): N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
+        # we need to find theta (cut off)
         search_space = (
             # wherever the score volume has not been explicitly set to -1 is the size of the search region
             (score_volume > -1).sum() *

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -72,7 +72,7 @@ def predict_tophat_mask(
     coeff_log = curve_fit(log_gauss, x_fit, np.log(y_fit), p0=coeff)[0]  # now go for accurate fit to log of gauss
     search_space = coeff_log[0] / (coeff_log[2] * np.sqrt(2 * np.pi))
     # formula Rickgauer et al. (2017, eLife): N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
-    # we need to find theta (cut off)
+    # we need to find theta (i.e. the cut-off)
     cut_off = erfcinv((2 * n_false_positives) / search_space) * np.sqrt(2) * coeff_log[2] + coeff_log[1]
 
     if plotting_available and output_path is not None:
@@ -163,7 +163,7 @@ def extract_particles(
     sigma = job.job_stats['std']
     if cut_off is None:
         # formula Rickgauer et al. (2017, eLife): N**(-1) = erfc( theta / ( sigma * sqrt(2) ) ) / 2
-        # we need to find theta (cut off)
+        # we need to find theta (i.e. the cut off)
         search_space = (
             # wherever the score volume has not been explicitly set to -1 is the size of the search region
             (score_volume > -1).sum() *

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -30,7 +30,7 @@ def predict_tophat_mask(
         score_volume: npt.NDArray[float],
         output_path: Optional[pathlib.Path] = None,
         n_false_positives: int = 1,
-) -> npt.NDArray[int]:
+) -> npt.NDArray[bool]:
     tophat = ndimage.white_tophat(
         score_volume,
         structure=ndimage.generate_binary_structure(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -8,7 +8,7 @@ class TestExtract(unittest.TestCase):
         rng = np.random.default_rng(0)
         volume = rng.normal(loc=0, scale=0.1, size=(50, ) * 3)  # generate random peaks
         tophat_mask = predict_tophat_mask(volume)
-        self.assertEqual(tophat_mask.shape, tophat_mask.shape, msg='tophat mask should have same size as input')
+        self.assertEqual(tophat_mask.shape, volume.shape, msg='tophat mask should have same size as input')
         self.assertEqual(tophat_mask.dtype, bool, msg='predicted tophat mask should be boolean')
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,16 @@
+import unittest
+import numpy as np
+from pytom_tm.extract import predict_tophat_mask
+
+
+class TestExtract(unittest.TestCase):
+    def test_predict_tophat_mask(self):
+        rng = np.random.default_rng(0)
+        volume = rng.normal(loc=0, scale=0.1, size=(50, ) * 3)  # generate random peaks
+        tophat_mask = predict_tophat_mask(volume)
+        self.assertEqual(tophat_mask.shape, tophat_mask.shape, msg='tophat mask should have same size as input')
+        self.assertEqual(tophat_mask.dtype, bool, msg='predicted tophat mask should be boolean')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This function is now quite stable and we also used it in processing some data in the group recently, so I think it would be good to merge it into the main branch and add a new version tag onto it. This way it can also be installed on the cluster. For users, the only addition to the previous version is the new '--tophat-filter' flag for pytom_extract_candidates.py. All previous functionality is identical.