### PR TITLE
Template.py: make filter warnings conditional and allow for no ctf_params

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -20,7 +20,7 @@ def generate_template_from_map(
         input_map: npt.NDArray[float],
         input_spacing: float,
         output_spacing: float,
-        ctf_params: dict,
+        ctf_params: Optional[dict] = None,
         center: bool = False,
         filter_to_resolution: Optional[float] = None,
         output_box_size: Optional[int] = None,

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -37,8 +37,9 @@ def generate_template_from_map(
         )
 
     if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
-        logging.warning(f'Filter resolution is either not specified (in which case you can ignore this warning) '
-                        f'or too low, changing to {2 * output_spacing}A (2 * output voxel size)')
+        warning_text = (f"Filter resoltution is {'not specified' if filter_to_resolution is None else 'too low'},"
+                        f" setting to {2 * output_spacing}A (2 * output voxel size)")
+        logging.warning(warning_text)
         filter_to_resolution = 2 * output_spacing
 
     # extend volume to the desired output size before applying convolutions!

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -36,7 +36,7 @@ def generate_template_from_map(
             mode='edge'
         )
 
-    if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
+    if filter_to_resolution is None:
         # Set to nyquist resolution
         filter_to_resolution = 2 * output_spacing
     elif filter_to_resolution < (2 * output_spacing):

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -37,7 +37,10 @@ def generate_template_from_map(
         )
 
     if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
-        warning_text = (f"Filter resolution is {'not specified' if filter_to_resolution is None else 'too low'},"
+        # Set to nyquist resolution
+        filter_to_resolution = 2 * output_spacing
+    elif filter_to_resolution < (2 * output_spacing):
+        warning_text = (f"Filter resolution is too low,"
                         f" setting to {2 * output_spacing}A (2 * output voxel size)")
         logging.warning(warning_text)
         filter_to_resolution = 2 * output_spacing

--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -37,7 +37,7 @@ def generate_template_from_map(
         )
 
     if filter_to_resolution is None or filter_to_resolution < (2 * output_spacing):
-        warning_text = (f"Filter resoltution is {'not specified' if filter_to_resolution is None else 'too low'},"
+        warning_text = (f"Filter resolution is {'not specified' if filter_to_resolution is None else 'too low'},"
                         f" setting to {2 * output_spacing}A (2 * output voxel size)")
         logging.warning(warning_text)
         filter_to_resolution = 2 * output_spacing

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,28 @@
+import unittest
+import numpy as np
+from pytom_tm.template import generate_template_from_map
+
+class TestLogging(unittest.TestCase):
+    def test_lowpass_resolution(self):
+        template = np.zeros((13, 13, 13), dtype=np.float32)
+
+        # Test missing filter resolution
+        with self.assertLogs(level='WARNING') as cm:
+            _ = generate_template_from_map(template, 1., 1.)
+        self.assertEqual(len(cm.output) == 1)
+        self.assertIn('Filter resolution', cm.output[0])
+        self.assertIn(' not specified ',cm.output[0])
+        self.assertNotIn(' too low ', cm.output[0])
+
+        # Test too low filter resolution
+        with self.assertLogs(level='WARNING') as cm:
+            _ = generate_template_from_map(template, 1., 1., filter_to_resolution=1.5)
+        self.assertEqual(len(cm.output) == 1)
+        self.assertIn('Filter resolution', cm.output[0])
+        self.assertNotIn(' not specified ',cm.output[0])
+        self.assertIn(' too low ', cm.output[0])
+
+        # Test working filter resolution
+        with self.assertNoLogs(level='WARNING'):
+            _ = generate_template_from_map(template, 1., 1., filter_to_resolution=2.5)
+ 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,16 +11,16 @@ class TestLogging(unittest.TestCase):
             _ = generate_template_from_map(template, 1., 1.)
         self.assertEqual(len(cm.output), 1)
         self.assertIn('Filter resolution', cm.output[0])
-        self.assertIn(' not specified ',cm.output[0])
-        self.assertNotIn(' too low ', cm.output[0])
+        self.assertIn(' not specified,',cm.output[0])
+        self.assertNotIn(' too low,', cm.output[0])
 
         # Test too low filter resolution
         with self.assertLogs(level='WARNING') as cm:
             _ = generate_template_from_map(template, 1., 1., filter_to_resolution=1.5)
         self.assertEqual(len(cm.output), 1)
         self.assertIn('Filter resolution', cm.output[0])
-        self.assertNotIn(' not specified ',cm.output[0])
-        self.assertIn(' too low ', cm.output[0])
+        self.assertNotIn(' not specified,',cm.output[0])
+        self.assertIn(' too low,', cm.output[0])
 
         # Test working filter resolution
         with self.assertNoLogs(level='WARNING'):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,21 +6,12 @@ class TestLogging(unittest.TestCase):
     def test_lowpass_resolution(self):
         template = np.zeros((13, 13, 13), dtype=np.float32)
 
-        # Test missing filter resolution
-        with self.assertLogs(level='WARNING') as cm:
-            _ = generate_template_from_map(template, 1., 1.)
-        self.assertEqual(len(cm.output), 1)
-        self.assertIn('Filter resolution', cm.output[0])
-        self.assertIn(' not specified,',cm.output[0])
-        self.assertNotIn(' too low,', cm.output[0])
-
         # Test too low filter resolution
         with self.assertLogs(level='WARNING') as cm:
             _ = generate_template_from_map(template, 1., 1., filter_to_resolution=1.5)
         self.assertEqual(len(cm.output), 1)
         self.assertIn('Filter resolution', cm.output[0])
-        self.assertNotIn(' not specified,',cm.output[0])
-        self.assertIn(' too low,', cm.output[0])
+        self.assertIn('too low', cm.output[0])
 
         # Test working filter resolution
         with self.assertNoLogs(level='WARNING'):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,7 +9,7 @@ class TestLogging(unittest.TestCase):
         # Test missing filter resolution
         with self.assertLogs(level='WARNING') as cm:
             _ = generate_template_from_map(template, 1., 1.)
-        self.assertEqual(len(cm.output) == 1)
+        self.assertEqual(len(cm.output), 1)
         self.assertIn('Filter resolution', cm.output[0])
         self.assertIn(' not specified ',cm.output[0])
         self.assertNotIn(' too low ', cm.output[0])
@@ -17,7 +17,7 @@ class TestLogging(unittest.TestCase):
         # Test too low filter resolution
         with self.assertLogs(level='WARNING') as cm:
             _ = generate_template_from_map(template, 1., 1., filter_to_resolution=1.5)
-        self.assertEqual(len(cm.output) == 1)
+        self.assertEqual(len(cm.output), 1)
         self.assertIn('Filter resolution', cm.output[0])
         self.assertNotIn(' not specified ',cm.output[0])
         self.assertIn(' too low ', cm.output[0])


### PR DESCRIPTION
replaces #88

I got a question from a novice user that thought it was bad when he did not specify the lowpass filter.
This now makes the log message conditional to the input

During the writing of the test I saw that there was code handeling `ctf_params=None` (line 73), so I added that option as a default to the call as well