### PR TITLE
Cupy13 workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">= 3.9"
 dependencies = [
     "numpy",
-    #"cupy",
+    "cupy",
     "voltools",
     "tqdm",
     "mrcfile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-template-matching-gpu"
-version = "0.3.4"
+version = "0.3.5"
 description = "GPU template matching from PyTOM as a lightweight pip package"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">= 3.9"
 dependencies = [
     "numpy",
-    "cupy",
+    #"cupy",
     "voltools",
     "tqdm",
     "mrcfile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytom-template-matching-gpu"
-version = "0.3.5"
+version = "0.3.4"
 description = "GPU template matching from PyTOM as a lightweight pip package"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -7,6 +7,7 @@ from typing import Optional
 from cupyx.scipy.fft import rfftn, irfftn, fftshift
 from tqdm import tqdm
 from pytom_tm.correlation import mean_under_mask, std_under_mask
+from packaging import version
 
 
 class TemplateMatchingPlan:
@@ -311,13 +312,18 @@ update_results_kernel = cp.ElementwiseKernel(
 )
 
 
-"""Calculate the sum of squares in a volume. Mean is assumed to be 0 which makes this operation a lot faster."""
-square_sum_kernel = cp.ReductionKernel(
-    'T x',  # input params
-    'T y',  # output params
-    'x * x',  # pre-processing expression
-    'a + b',  # reduction operation
-    'y = a',  # post-reduction output processing
-    '0',  # identity value
-    'variance'  # kernel name
-)
+# Temporary workaround for ReductionKernel issue in cupy 13.0.0 (see: https://github.com/cupy/cupy/issues/8184)
+if version.parse(cp.__version__) == version.parse('13.0.0'):
+    def square_sum_kernel(x):
+        return (x ** 2).sum()
+else:
+    """Calculate the sum of squares in a volume. Mean is assumed to be 0 which makes this operation a lot faster."""
+    square_sum_kernel = cp.ReductionKernel(
+        'T x',  # input params
+        'T y',  # output params
+        'x * x',  # pre-processing expression
+        'a + b',  # reduction operation
+        'y = a',  # post-reduction output processing
+        '0',  # identity value
+        'variance'  # kernel name
+    )


### PR DESCRIPTION
Temporary workaround for ReductionKernel bug in cupy 13. Code checks if cupy version 13 is installed and switch to simple 

```
def square_sum_kernel(x):
        return (x ** 2).sum()
```
, instead of custom kernel.

See issue #106 for more info. The custom kernel is still preferred as it provides a ~2 x speed up.