### PR TITLE
update install instructions to prefer building cupy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ nvidia-cuda-toolkit
 
 ## Installation
 
-There are 2 options for creating a conda environment. We recommend option (1) which builds cupy against a system 
-installed cuda-toolkit. Compared to option (2) this can give an almost two-fold speedup.
+There are 2 options for creating a conda environment. We recommend option (1) which will later allow cupy to build 
+against a system installed cuda-toolkit. Compared to option (2) this can give an almost two-fold speedup:
 
-1. **(recommended)** Create a new environment without cupy and let the pip installation build cupy against a system 
-   installed CUDA-toolkit.
+1. **(recommended)** Create a new python 3 environment:
 
     ```commandline
     conda create -n pytom_tm python=3
     ```
 
-2.  Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is reliable but takes more 
-    disk space.
+2.  Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is reliable, but takes more 
+    disk space and has less optimal performance.
 
     ```commandline
     conda create -n pytom_tm -c conda-forge python=3 cupy cuda-version=11.8
@@ -36,7 +35,7 @@ Once the environment is created, activate it:
 conda activate pytom_tm
 ```
 
-Then clone the repository and install it with pip: 
+Then clone the repository and install it with pip (building cupy can take a while!): 
 
 ```commandline
 git clone https://github.com/SBC-Utrecht/pytom-template-matching-gpu.git

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ against a system installed cuda-toolkit. Compared to option (2) this can give an
     conda create -n pytom_tm python=3
     ```
 
-2.  Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is reliable, but takes more 
+2.  Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is more reliable, but takes more 
     disk space and has less optimal performance.
 
     ```commandline

--- a/README.md
+++ b/README.md
@@ -12,19 +12,23 @@ nvidia-cuda-toolkit
 
 ## Installation
 
-There are 2 options for creating a conda environment:
+There are 2 options for creating a conda environment. We recommend option (1) which builds cupy against a system 
+installed cuda-toolkit. Compared to option (2) this can give an almost two-fold speedup.
 
-1. **(recommended)** Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is reliable but takes more disk space.
+1. **(recommended)** Create a new environment without cupy and let the pip installation build cupy against a system 
+   installed CUDA-toolkit.
+
+    ```commandline
+    conda create -n pytom_tm python=3
+    ```
+
+2.  Create a new environment with a prebuild cupy version and complete CUDA-toolkit. This is reliable but takes more 
+    disk space.
 
     ```commandline
     conda create -n pytom_tm -c conda-forge python=3 cupy cuda-version=11.8
     ```
 
-2. Create a new environment without cupy and let pip build against a system installed CUDA-toolkit.
-
-    ```commandline
-    conda create -n pytom_tm python=3
-    ```
 
 Once the environment is created, activate it:
 
@@ -40,7 +44,9 @@ cd pytom-template-matching-gpu
 python -m pip install '.[plotting]'
 ```
 
-The installation above also adds the optional dependencies `[matplotlib, seaborn]` which are required to run `pytom_estimate_roc.py`. They are not essential to the core template matching fucntionality, so for some systems (such as certain cluster environments) it might be desirable to skip them. In that case remove `[plotting]` from the pip install command:
+The installation above also adds the optional dependencies `[matplotlib, seaborn]` which are required to run 
+`pytom_estimate_roc.py`. They are not essential to the core template matching functionality, so for some systems 
+(such as certain cluster environments) it might be desirable to skip them. In that case remove `[plotting]` from the pip install command:
 
 ```commandline
 python -m pip install .


### PR DESCRIPTION
I updated the installation instuctions in the README to prefer letting cupy build against a preinstalled cuda toolkit as the gain in performance is almost two-fold on our cluster. 

I tried building cupy against a cuda toolkit in the miniconda environment, but the result was that cupy still installed against the system installation. So I just left it as the reliable option to pull it directly from conda-forge.

related to issue #101