### PR TITLE
Slicing for std calculation

### DIFF
--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -272,7 +272,7 @@ def extract_particles(
     ]), scores
 
     if plotting_available:
-        y, bins = np.histogram(scores, bins=15)
+        y, bins = np.histogram(scores, bins=20)
         x = (bins[1:] + bins[:-1]) / 2
         hist_step = bins[1] - bins[0]
         # add 10 more starting values
@@ -290,7 +290,11 @@ def extract_particles(
         ax.set_xlabel(r'${LCC}_{max}$')
         ax.legend()
         plt.tight_layout()
-        plt.savefig(job.output_dir.joinpath(f'{job.tomo_id}_extraction_graph.svg'), dpi=600, transparent=False,
-                    bbox_inches='tight')
+        plt.savefig(
+            job.output_dir.joinpath(f'{job.tomo_id}_extraction_graph.svg'),
+            dpi=600,
+            transparent=False,
+            bbox_inches='tight'
+        )
 
     return output

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -285,7 +285,7 @@ def extract_particles(
         ax.scatter(x, y, label='scores', marker='o')
         ax.plot(x_ext, y_background, label='background', color='tab:orange')
         ax.axvline(cut_off, color='gray', linestyle='dashed', label='cut-off')
-        ax.set_ylim(top=(3 / 2) * max(y))
+        ax.set_ylim(bottom=0, top=(3 / 2) * max(y))
         ax.set_ylabel('Occurence')
         ax.set_xlabel(r'${LCC}_{max}$')
         ax.legend()

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -103,7 +103,7 @@ def predict_tophat_mask(
 
     if plotting_available and output_path is not None:
         fig, ax = plt.subplots()
-        ax.scatter(x_raw, y_raw, label='scores', marker='o')
+        ax.scatter(x_raw, y_raw, label='tophat', marker='o')
         ax.plot(x_raw, gauss(x_raw, *coeff_log), label='pred', color='tab:orange')
         ax.axvline(cut_off, color='gray', linestyle='dashed', label='cut-off')
         ax.axvspan(x_fit[0], x_fit[-1], alpha=0.25, color='gray', label='fitted data')
@@ -282,7 +282,7 @@ def extract_particles(
         y_background = noise_amplitude * np.exp(- x_ext ** 2 / (2 * noise_sigma ** 2))
 
         fig, ax = plt.subplots()
-        ax.scatter(x, y, label='scores', marker='o')
+        ax.scatter(x, y, label='extracted', marker='o')
         ax.plot(x_ext, y_background, label='background', color='tab:orange')
         ax.axvline(cut_off, color='gray', linestyle='dashed', label='cut-off')
         ax.set_ylim(bottom=0, top=2 * max(y))

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -272,11 +272,11 @@ def extract_particles(
     ]), scores
 
     if plotting_available:
-        y, bins = np.histogram(scores, bins=30)
+        y, bins = np.histogram(scores, bins=15)
         x = (bins[1:] + bins[:-1]) / 2
         hist_step = bins[1] - bins[0]
         # add 10 more starting values
-        x_ext = np.concatenate((np.linspace(x[0] - 10 * hist_step, x[0], 10), x))
+        x_ext = np.concatenate((np.linspace(x[0] - 5 * hist_step, x[0], 10), x))
         noise_sigma = job.job_stats['std']
         noise_amplitude = (job.job_stats['search_space'] / (noise_sigma * np.sqrt(2 * np.pi))) * hist_step
         y_background = noise_amplitude * np.exp(- x_ext ** 2 / (2 * noise_sigma ** 2))
@@ -285,7 +285,7 @@ def extract_particles(
         ax.scatter(x, y, label='scores', marker='o')
         ax.plot(x_ext, y_background, label='background', color='tab:orange')
         ax.axvline(cut_off, color='gray', linestyle='dashed', label='cut-off')
-        ax.set_ylim(bottom=0, top=(3 / 2) * max(y))
+        ax.set_ylim(bottom=0, top=2 * max(y))
         ax.set_ylabel('Occurence')
         ax.set_xlabel(r'${LCC}_{max}$')
         ax.legend()

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -128,6 +128,7 @@ def extract_particles(
         n_false_positives: int = 1,
         tomogram_mask_path: Optional[pathlib.Path] = None,
         tophat_filter: bool = False,
+        create_plot: bool = True
 ) -> tuple[pd.DataFrame, list[float, ...]]:
     """
     Parameters
@@ -147,6 +148,8 @@ def extract_particles(
         path to a tomographic binary mask for extraction
     tophat_filter: bool
         attempt to only select sharp peaks with the tophat filter
+    create_plot: bool, default True
+        flag for creating extraction plots
 
     Returns
     -------
@@ -165,7 +168,7 @@ def extract_particles(
         predicted_peaks = predict_tophat_mask(
             score_volume,
             output_path=job.output_dir.joinpath(f'{job.tomo_id}_tophat_filter.svg'),
-            n_false_positives=n_false_positives,
+            n_false_positives=n_false_positives
         )
         score_volume *= predicted_peaks  # multiply with predicted peaks to keep only those
 
@@ -267,7 +270,7 @@ def extract_particles(
         'ptmMicrographName',
     ]), scores
 
-    if plotting_available:
+    if plotting_available and create_plot:
         y, bins = np.histogram(scores, bins=20)
         x = (bins[1:] + bins[:-1]) / 2
         hist_step = bins[1] - bins[0]

--- a/src/pytom_tm/extract.py
+++ b/src/pytom_tm/extract.py
@@ -283,7 +283,7 @@ def extract_particles(
 
         fig, ax = plt.subplots()
         ax.scatter(x, y, label='scores', marker='o')
-        ax.plot(x_ext, y_background, label='background', color='tab:orage')
+        ax.plot(x_ext, y_background, label='background', color='tab:orange')
         ax.axvline(cut_off, color='gray', linestyle='dashed', label='cut-off')
         ax.set_ylim(top=(3 / 2) * max(y))
         ax.set_ylabel('Occurence')

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -129,9 +129,9 @@ class TemplateMatchingGPU:
         self.stats = {'search_space': 0, 'variance': 0., 'std': 0.}
         if stats_roi is None:
             self.stats_roi = (
-                slice(0, volume.shape[0]),
-                slice(0, volume.shape[1]),
-                slice(0, volume.shape[2])
+                slice(None),
+                slice(None),
+                slice(None)
             )
         else:
             self.stats_roi = stats_roi

--- a/src/pytom_tm/matching.py
+++ b/src/pytom_tm/matching.py
@@ -243,9 +243,9 @@ class TemplateMatchingGPU:
             )
 
             self.stats['variance'] += (
-                    square_sum_kernel(
-                        self.plan.ccc_map[self.stats_roi]
-                    ) / roi_size
+                square_sum_kernel(
+                    self.plan.ccc_map[self.stats_roi]
+                ) / roi_size
             )
 
         self.stats['search_space'] = int(roi_size * len(self.angle_ids))

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -621,7 +621,6 @@ class TMJob:
             slice(self.sub_start[1], self.sub_start[1] + self.sub_step[1]),
             slice(self.sub_start[2], self.sub_start[2] + self.sub_step[2])
         )
-        print(search_volume_roi)
 
         tm = TemplateMatchingGPU(
             job_id=self.job_key,

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -208,8 +208,9 @@ class TMJob:
         logging.debug(f'origin, size = {self.search_origin}, {self.search_size}')
 
         self.whole_start = None
-        # for the main job these are always [0,0,0] and self.search_size, for sub_jobs these will differ from the
-        # search origin and search size
+        # For the main job these are always [0,0,0] and self.search_size, for sub_jobs these will differ from the
+        # search origin and search size. The main job only uses them to calculate the search_volume_roi for statistics.
+        # Sub jobs also use these to extract the relevant region and placing it back in the master job.
         self.sub_start, self.sub_step = [0, 0, 0], self.search_size.copy()
 
         # Rotation parameters
@@ -615,9 +616,11 @@ class TMJob:
         )]
 
         # slices for relevant part for job statistics
-        x_slice = slice(self.sub_start[0], self.sub_start[0] + self.sub_step[0])
-        y_slice = slice(self.sub_start[1], self.sub_start[1] + self.sub_step[1])
-        z_slice = slice(self.sub_start[2], self.sub_start[2] + self.sub_step[2])
+        search_volume_roi = (
+            slice(self.sub_start[0], self.sub_start[0] + self.sub_step[0]),
+            slice(self.sub_start[1], self.sub_start[1] + self.sub_step[1]),
+            slice(self.sub_start[2], self.sub_start[2] + self.sub_step[2])
+        )
 
         tm = TemplateMatchingGPU(
             job_id=self.job_key,
@@ -627,7 +630,7 @@ class TMJob:
             mask=mask,
             angle_list=angle_list,
             angle_ids=angle_ids,
-            stats_roi=(x_slice, y_slice, z_slice),
+            stats_roi=search_volume_roi,
             mask_is_spherical=self.mask_is_spherical,
             wedge=template_wedge
         )

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -405,13 +405,12 @@ class TMJob:
             if start[2] != self.search_origin[2]:
                 whole_start[2] = start[2] + template_shape[2] // 2 - self.search_origin[2]
                 sub_start[2] = template_shape[2] // 2
-            # if this is the last box on an axis, sub_step != split_size -- take ceil for uneven template size
             if end[0] == self.search_origin[0] + self.search_size[0]:
-                sub_step[0] = self.search_size[0] - whole_start[0]
+                sub_step[0] = size[0] - sub_start[0]
             if end[1] == self.search_origin[1] + self.search_size[1]:
-                sub_step[1] = self.search_size[1] - whole_start[1]
+                sub_step[1] = size[1] - sub_start[1]
             if end[2] == self.search_origin[2] + self.search_size[2]:
-                sub_step[2] = self.search_size[2] - whole_start[2]
+                sub_step[2] = size[2] - sub_start[2]
 
             # create a split volume job
             new_job = self.copy()

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -621,6 +621,7 @@ class TMJob:
             slice(self.sub_start[1], self.sub_start[1] + self.sub_step[1]),
             slice(self.sub_start[2], self.sub_start[2] + self.sub_step[2])
         )
+        print(search_volume_roi)
 
         tm = TemplateMatchingGPU(
             job_id=self.job_key,
@@ -630,9 +631,9 @@ class TMJob:
             mask=mask,
             angle_list=angle_list,
             angle_ids=angle_ids,
-            stats_roi=search_volume_roi,
             mask_is_spherical=self.mask_is_spherical,
-            wedge=template_wedge
+            wedge=template_wedge,
+            stats_roi=search_volume_roi
         )
         results = tm.run()
         score_volume = results[0][:self.search_size[0], :self.search_size[1], :self.search_size[2]]

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -456,13 +456,13 @@ class TMJob:
             return result
 
         if stats is not None:
-            search_space = sum([s['search_space'] for s in stats])  #reduce(
-            #     lambda x, y: x * y,
-            #     self.search_size
-            # ) * int(np.ceil(self.n_rotations / self.rotational_symmetry))
+            search_space = sum([s['search_space'] for s in stats])
             variance = sum([s['variance'] for s in stats]) / len(stats)
-            std = np.sqrt(variance)
-            self.job_stats = {'search_space': search_space, 'variance': variance, 'std': std}
+            self.job_stats = {
+                'search_space': search_space,
+                'variance': variance,
+                'std': np.sqrt(variance)
+            }
 
         is_subvolume_split = np.all(np.array([x.start_slice for x in self.sub_jobs]) == 0)
 

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -208,7 +208,9 @@ class TMJob:
         logging.debug(f'origin, size = {self.search_origin}, {self.search_size}')
 
         self.whole_start = None
-        self.sub_start, self.sub_step = None, None
+        # for the main job these are always [0,0,0] and self.search_size, for sub_jobs these will differ from the
+        # search origin and search size
+        self.sub_start, self.sub_step = [0, 0, 0], self.search_size.copy()
 
         # Rotation parameters
         self.start_slice = 0
@@ -612,6 +614,11 @@ class TMJob:
             self.steps_slice
         )]
 
+        # slices for relevant part for job statistics
+        x_slice = slice(self.sub_start[0], self.sub_start[0] + self.sub_step[0])
+        y_slice = slice(self.sub_start[1], self.sub_start[1] + self.sub_step[1])
+        z_slice = slice(self.sub_start[2], self.sub_start[2] + self.sub_step[2])
+
         tm = TemplateMatchingGPU(
             job_id=self.job_key,
             device_id=gpu_id,
@@ -620,6 +627,7 @@ class TMJob:
             mask=mask,
             angle_list=angle_list,
             angle_ids=angle_ids,
+            stats_roi=(x_slice, y_slice, z_slice),
             mask_is_spherical=self.mask_is_spherical,
             wedge=template_wedge
         )

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -247,13 +247,13 @@ class TestTMJob(unittest.TestCase):
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 
-        print(self.job.job_stats)
         split_stats = self.job.job_stats
         reference_stats = load_json_to_tmjob(TEST_JOB_JSON).job_stats
-        print(reference_stats)
+        # print(self.job.job_stats)
+        # print(reference_stats)
         self.assertEqual(split_stats['search_space'], reference_stats['search_space'],
                          msg='Search space should remain identical upon subvolume splitting.')
-        self.assertAlmostEqual(split_stats['std'], reference_stats['std'], places=6,
+        self.assertAlmostEqual(split_stats['std'], reference_stats['std'], places=3,
                                msg='Standard deviation over search should be almost identical.')
 
     def test_splitting_with_offsets(self):

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -6,7 +6,7 @@ import mrcfile
 from importlib_resources import files
 from pytom_tm.mask import spherical_mask
 from pytom_tm.angles import load_angle_list
-from pytom_tm.tmjob import TMJob, TMJobError
+from pytom_tm.tmjob import TMJob, TMJobError, load_json_to_tmjob
 from pytom_tm.io import read_mrc, write_mrc, UnequalSpacingError
 from pytom_tm.extract import extract_particles
 from test_weights import CTF_PARAMS, ACCUMULATED_DOSE, TILT_ANGLES
@@ -29,6 +29,7 @@ TEST_SCORES = TEST_DATA_DIR.joinpath('tomogram_scores.mrc')
 TEST_ANGLES = TEST_DATA_DIR.joinpath('tomogram_angles.mrc')
 TEST_CUSTOM_ANGULAR_SEARCH = TEST_DATA_DIR.joinpath('custom_angular_search.txt')
 TEST_WHITENING_FILTER = TEST_DATA_DIR.joinpath('tomogram_whitening_filter.npy')
+TEST_JOB_JSON = TEST_DATA_DIR.joinpath('tomogram_job.json')
 
 
 class TestTMJob(unittest.TestCase):
@@ -93,6 +94,7 @@ class TestTMJob(unittest.TestCase):
             angle,
             job.voxel_size
         )
+        job.write_to_json(TEST_JOB_JSON)
 
         np.savetxt(TEST_CUSTOM_ANGULAR_SEARCH, np.random.rand(100, 3))
 
@@ -111,6 +113,7 @@ class TestTMJob(unittest.TestCase):
         # the whitening filter might not exist if the job with spectrum whitening failed, so the unlinking needs to
         # allow this (with missing_ok=True) to ensure clean up of the test directory
         TEST_WHITENING_FILTER.unlink(missing_ok=True)
+        TEST_JOB_JSON.unlink()
         TEST_DATA_DIR.rmdir()
 
     def setUp(self):
@@ -208,8 +211,9 @@ class TestTMJob(unittest.TestCase):
             self.job.split_volume_search((10, 3, 2))
 
         sub_jobs = self.job.split_volume_search((2, 3, 2))
+        stats = []
         for x in sub_jobs:
-            x.start_job(0)
+            stats.append(x.start_job(0))
             job_scores = TEST_DATA_DIR.joinpath(f'tomogram_scores_{x.job_key}.mrc')
             job_angles = TEST_DATA_DIR.joinpath(f'tomogram_angles_{x.job_key}.mrc')
             self.assertTrue(
@@ -220,7 +224,7 @@ class TestTMJob(unittest.TestCase):
                 job_angles.exists(),
                 msg='Expected output from job does not exist.'
             )
-        score, angle = self.job.merge_sub_jobs()
+        score, angle = self.job.merge_sub_jobs(stats)
         ind = np.unravel_index(score.argmax(), score.shape)
 
         self.assertTrue(score.max() > 0.931, msg='lcc max value lower than expected')
@@ -243,6 +247,16 @@ class TestTMJob(unittest.TestCase):
         self.assertAlmostEqual(score_diff, 0, places=1, msg='score diff should not be larger than 0.01')
         self.assertAlmostEqual(angle_diff, 0, places=1, msg='angle diff should not change')
 
+        print(self.job.job_stats)
+        split_stats = self.job.job_stats
+        reference_stats = load_json_to_tmjob(TEST_JOB_JSON).job_stats
+        print(reference_stats)
+        self.assertEqual(split_stats['search_space'], reference_stats['search_space'],
+                         msg='Search space should remain identical upon subvolume splitting.')
+        self.assertAlmostEqual(split_stats['std'], reference_stats['std'], places=6,
+                               msg='Standard deviation over search should be almost identical.')
+
+    def test_splitting_with_offsets(self):
         # check if subjobs have correct offsets for the main job, the last sub job will have the largest errors
         job = TMJob('0', 10, TEST_TOMOGRAM, TEST_TEMPLATE, TEST_MASK, TEST_DATA_DIR,
                     angle_increment='38.53', voxel_size=1., search_x=[9, 90], search_y=[25, 102], search_z=[19, 54])

--- a/tests/test_tmjob.py
+++ b/tests/test_tmjob.py
@@ -30,7 +30,6 @@ TEST_ANGLES = TEST_DATA_DIR.joinpath('tomogram_angles.mrc')
 TEST_CUSTOM_ANGULAR_SEARCH = TEST_DATA_DIR.joinpath('custom_angular_search.txt')
 TEST_WHITENING_FILTER = TEST_DATA_DIR.joinpath('tomogram_whitening_filter.npy')
 TEST_JOB_JSON = TEST_DATA_DIR.joinpath('tomogram_job.json')
-TEST_JOB_JSON = TEST_DATA_DIR.joinpath('tomogram_job.json')
 
 
 class TestTMJob(unittest.TestCase):


### PR DESCRIPTION
This PR improves the calculation of the standard deviation over a template matching search. It closes #97.

First some background on why I updated this. Template matching has a huge search space (N_voxels * rotations) which is mainly false positives, and has in comparison a tiny fraction of true positives. If we have a Gaussian for the background (with expected mean 0 and some standard deviation), the false alarm rate can be calculated for a certain cut-off value, as it is dependent on the size of the search space. For example, a false alarm rate of (N_voxels * rotations)^(-1), indicates it would expect 1 false positive in the whole search. This can be calculated with error function,

$$N^{-1} = erfc( \theta / ( \sigma \sqrt{2} ) ) / 2$$

, where theta is the cut-off, sigma the standard deviation of the Gaussian, and N the search space.

The search space is easily calculated, the standard deviation can be kept tracked of for each orientation (which is what this custom square_sum_kernel is used for). However there were true problems:
- with the next_fast_len for ffts the volume was padded with zeros that were also incorporated in the square_sum_kernel.
- with subvolume splitting I added overhang between subvolumes, needed for accurate scores, but these regions were incorporated doubly in the standard deviation calculation.

I fixed it by passing a search_volume_roi to template matching which contains the actual region of interest wihout fft padding and without template overhang. The indexing is already calculated, so I just created a slicing for the cupy array.

I first added tests to check whether the search_space and std are consistent with subvolume splitting (and also rotation splitting), and realised there was a bug in tmjob.py in calculating the start of the subvolume (lines 380 to 384): I did not put brackets around `template_size // 2` which messes with integer division with the minus sign in front :weary: . This is now fixed. 

I also added plotting of an extraction graph which shows a histogram of extracted scores together with the background Gaussian (as this is now properly estimated). Which I think is nice for users to see. 

Let me know if anything is unclear.