### PR TITLE
small fixes for template generation and preparation

### DIFF
--- a/src/pytom_tm/template.py
+++ b/src/pytom_tm/template.py
@@ -58,7 +58,8 @@ def generate_template_from_map(
         input_map = np.pad(
             input_map,
             tuple([(d // 2, d // 2 + d % 2) for d in diff]),
-            mode='edge'
+            mode='constant',
+            constant_values=0,
         )
 
     if filter_to_resolution is None:
@@ -79,7 +80,8 @@ def generate_template_from_map(
             input_map = np.pad(
                 input_map,
                 (pad // 2, pad // 2 + pad % 2),
-                mode='edge'
+                mode='constant',
+                constant_values=0
             )
         elif output_box_size < (input_map.shape[0] * input_spacing) // output_spacing:
             logging.warning('Could not set specified box size as the map would need to be cut and this might '

--- a/src/pytom_tm/tmjob.py
+++ b/src/pytom_tm/tmjob.py
@@ -553,6 +553,8 @@ class TMJob:
             read_mrc(self.template),
             read_mrc(self.mask)
         )
+        # apply mask directly to prevent any wedge convolution with weird edges
+        template *= mask
 
         # init tomogram and template weighting
         tomo_filter, template_wedge = 1, 1


### PR DESCRIPTION
Two small changes here because I encountered issues with these things in the dataset I am processing.

Template generation used to do padding with edge mode (left image) and now instead pads with zeros (right). This reduces edge artifacts if the reference structure has a zeroed background (which should be the case for EM maps!).

![pytom-template_with_and_without_zero_padding](https://github.com/SBC-Utrecht/pytom-template-matching-gpu/assets/58044494/f06a87cf-4b85-414d-a32f-ae9e5856f618)

Second change is that the template is now always multiplied with the mask before starting template matching (instead of after applying the wedge), this significantly reduces artifacts from convolution with the missing wedge. Left image is before, right image is after:

![pytom-wedge_with_and_without_prior_masking](https://github.com/SBC-Utrecht/pytom-template-matching-gpu/assets/58044494/37586b45-e7dc-48c2-97e8-0348aec2f5ee)



